### PR TITLE
Stronger constraints on EnumerableSerializerFactory + tests

### DIFF
--- a/Hyperion/SerializerFactories/EnumerableSerializerFactory.cs
+++ b/Hyperion/SerializerFactories/EnumerableSerializerFactory.cs
@@ -24,20 +24,33 @@ namespace Hyperion.SerializerFactories
         {
             //TODO: check for constructor with IEnumerable<T> param
 
-            if (!type.GetTypeInfo().GetMethods().Any(m => m.Name == "AddRange" || m.Name == "Add"))
+            var countProperty = type.GetTypeInfo().GetProperty("Count");
+            if (countProperty == null || countProperty.PropertyType != typeof(int))
                 return false;
 
-            if (type.GetTypeInfo().GetProperty("Count") == null)
+            if (!type.GetTypeInfo().GetMethods().Any(IsAddMethod))
                 return false;
 
             var isGenericEnumerable = GetEnumerableType(type) != null;
             if (isGenericEnumerable)
                 return true;
 
-            if (typeof (ICollection).GetTypeInfo().IsAssignableFrom(type))
+            if (typeof(ICollection).GetTypeInfo().IsAssignableFrom(type))
                 return true;
 
             return false;
+        }
+
+        private static bool IsAddMethod(MethodInfo methodInfo) => 
+            (methodInfo.Name == "AddRange" || methodInfo.Name == "Add")
+            && methodInfo.ReturnType == typeof(void)
+            && !methodInfo.IsStatic
+            && HasValidParameters(methodInfo);
+
+        private static bool HasValidParameters(MethodInfo methodInfo)
+        {
+            var parameters = methodInfo.GetParameters();
+            return parameters.Length == 1;
         }
 
         public override bool CanDeserialize(Serializer serializer, Type type)
@@ -50,7 +63,7 @@ namespace Hyperion.SerializerFactories
             return type
                 .GetTypeInfo()
                 .GetInterfaces()
-                .Where(intType => intType.GetTypeInfo().IsGenericType && intType.GetTypeInfo().GetGenericTypeDefinition() == typeof (IEnumerable<>))
+                .Where(intType => intType.GetTypeInfo().IsGenericType && intType.GetTypeInfo().GetGenericTypeDefinition() == typeof(IEnumerable<>))
                 .Select(intType => intType.GetTypeInfo().GetGenericArguments()[0])
                 .FirstOrDefault();
         }
@@ -62,7 +75,7 @@ namespace Hyperion.SerializerFactories
             typeMapping.TryAdd(type, x);
             var preserveObjectReferences = serializer.Options.PreserveObjectReferences;
 
-            var elementType = GetEnumerableType(type) ?? typeof (object);
+            var elementType = GetEnumerableType(type) ?? typeof(object);
             var elementSerializer = serializer.GetSerializerByType(elementType);
 
             var countProperty = type.GetTypeInfo().GetProperty("Count");
@@ -81,7 +94,7 @@ namespace Hyperion.SerializerFactories
                 }
 
                 var count = stream.ReadInt32(session);
-               
+
                 if (addRange != null)
                 {
                     var items = Array.CreateInstance(elementType, count);
@@ -92,7 +105,7 @@ namespace Hyperion.SerializerFactories
                     }
                     //HACK: this needs to be fixed, codegenerated or whatever
 
-                    addRange.Invoke(instance, new object[] {items});
+                    addRange.Invoke(instance, new object[] { items });
                     return instance;
                 }
                 if (add != null)
@@ -114,7 +127,7 @@ namespace Hyperion.SerializerFactories
                 {
                     session.TrackSerializedObject(o);
                 }
-                Int32Serializer.WriteValueImpl(stream, countGetter(o),session);
+                Int32Serializer.WriteValueImpl(stream, countGetter(o), session);
                 var enumerable = o as IEnumerable;
                 // ReSharper disable once PossibleNullReferenceException
                 foreach (var value in enumerable)


### PR DESCRIPTION
This PR provides fix for #18 with tests to verify valid behavior.

I've still left a one edge case - when `Add`/`AddRange` methods have indeed only a single input param, but it doesn't match the type of the serialized value that we want to insert. But I think, this is really edgy and I'm not sure if it's worth checking.

/cc akkadotnet/akka.net#2421