### PR TITLE
[WIP] MarshalSerializer for structs

### DIFF
--- a/Hyperion.Tests/Hyperion.Tests.csproj
+++ b/Hyperion.Tests/Hyperion.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="IlCompilerTests.cs" />
     <Compile Include="ImmutableCollectionsTests.cs" />
     <Compile Include="InterfaceTests.cs" />
+    <Compile Include="MarshalSerializerTests.cs" />
     <Compile Include="UnsupportedTypeSerializerTests.cs" />
     <Compile Include="ISerializableTests.cs" />
     <Compile Include="PrimitivesTests.cs" />

--- a/Hyperion.Tests/MarshalSerializerTests.cs
+++ b/Hyperion.Tests/MarshalSerializerTests.cs
@@ -1,0 +1,47 @@
+﻿#region copyright
+// -----------------------------------------------------------------------
+//  <copyright file="MarshaledValueSerializerFactory.cs" company="Akka.NET Team">
+//      Copyright (C) 2017-2017 Akka.NET Team <https://github.com/akkadotnet>
+//  </copyright>
+// -----------------------------------------------------------------------
+#endregion
+
+using Hyperion.SerializerFactories;
+using Xunit;
+
+namespace Hyperion.Tests
+{
+    public class MarshalSerializerTests : TestBase
+    {
+        public struct MyStruct
+        {
+            public readonly int X;
+            public readonly int Y;
+            public readonly int Z;
+
+            public MyStruct(int x, int y, int z)
+            {
+                X = x;
+                Y = y;
+                Z = z;
+            }
+        }
+
+        public MarshalSerializerTests()
+        {
+            CustomInit(new Serializer(new SerializerOptions(
+                serializerFactories: new[] { new MarshalSerializerFactory(), })));
+        }
+
+        [Fact]
+        public void CanSerializerFullyValuedTypesUsingMarshaller()
+        {
+            var expected = new MyStruct(1337, 293256, 235034634);
+
+            Serialize(expected);
+            Reset();
+            var actual = Deserialize<MyStruct>();
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/Hyperion/Hyperion.csproj
+++ b/Hyperion/Hyperion.csproj
@@ -72,6 +72,7 @@
     <Compile Include="SerializerFactories\ImmutableCollectionsSerializerFactory.cs" />
     <Compile Include="SerializerFactories\ISerializableSerializerFactory.cs" />
     <Compile Include="SerializerFactories\LinkedListSerializerFactory.cs" />
+    <Compile Include="SerializerFactories\MarshalSerializerFactory.cs" />
     <Compile Include="SerializerFactories\MethodInfoSerializerFactory.cs" />
     <Compile Include="SerializerFactories\ToSurrogateSerializerFactory.cs" />
     <Compile Include="SerializerFactories\ValueSerializerFactory.cs" />

--- a/Hyperion/SerializerFactories/MarshalSerializerFactory.cs
+++ b/Hyperion/SerializerFactories/MarshalSerializerFactory.cs
@@ -1,0 +1,79 @@
+﻿#region copyright
+// -----------------------------------------------------------------------
+//  <copyright file="MarshaledValueSerializerFactory.cs" company="Akka.NET Team">
+//      Copyright (C) 2017-2017 Akka.NET Team <https://github.com/akkadotnet>
+//  </copyright>
+// -----------------------------------------------------------------------
+#endregion
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Hyperion.Extensions;
+using Hyperion.ValueSerializers;
+
+namespace Hyperion.SerializerFactories
+{
+    public class MarshalSerializerFactory : ValueSerializerFactory
+    {
+        public override bool CanSerialize(Serializer serializer, Type type) =>
+            !serializer.Options.VersionTolerance && IsFullValueType(type, new HashSet<Type>());
+
+        public override bool CanDeserialize(Serializer serializer, Type type) =>
+            !serializer.Options.VersionTolerance && IsFullValueType(type, new HashSet<Type>());
+
+        private bool IsFullValueType(Type type, HashSet<Type> acknowledged)
+        {
+            if (!type.IsValueType) return false;
+
+            acknowledged.Add(type);
+
+            var fields = type.GetFieldInfosForType();
+
+            var result = true;
+            for (int i = 0; i < fields.Length; i++)
+            {
+                var fieldType = fields[i].FieldType;
+                result &= acknowledged.Contains(fieldType) || IsFullValueType(fieldType, acknowledged);
+            }
+
+            return result;
+        }
+
+        public override ValueSerializer BuildSerializer(Serializer serializer, Type type, ConcurrentDictionary<Type, ValueSerializer> typeMapping)
+        {
+            var ser = new ObjectSerializer(type);
+            typeMapping.TryAdd(type, ser);
+
+            var size = Marshal.SizeOf(type);
+            ObjectWriter writer = (stream, value, session) =>
+            {
+                var bin = new byte[size];
+
+                var ptr = Marshal.AllocHGlobal(size);
+                Marshal.StructureToPtr(value, ptr, true);
+                Marshal.Copy(ptr, bin, 0, size);
+                Marshal.FreeHGlobal(ptr);
+
+                stream.Write(bin, 0, size);
+            };
+
+            ObjectReader reader = (stream, session) =>
+            {
+                var ptr = Marshal.AllocHGlobal(size);
+                var bin = new byte[size];
+                stream.Read(bin, 0, size);
+
+                Marshal.Copy(bin, 0, ptr, size);
+
+                var value = Marshal.PtrToStructure(ptr, type);
+                Marshal.FreeHGlobal(ptr);
+                return value;
+            };
+            ser.Initialize(reader, writer);
+
+            return ser;
+        }
+    }
+}


### PR DESCRIPTION
**Work in progress**

This is a experimental serializer for structs that uses `Marshal` class for direct struct &rarr; byte array mapping instead of writing values field by field. Some initial benchmarks:

``` ini

BenchmarkDotNet=v0.10.1, OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i5-6300HQ CPU 2.30GHz, ProcessorCount=4
Frequency=2249998 Hz, Resolution=444.4448 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 32bit LegacyJIT-v4.6.1586.0
  DefaultJob : Clr 4.0.30319.42000, 32bit LegacyJIT-v4.6.1586.0


```
                                    Method |      Mean |    StdDev |       Min |       Max |      Op/s |  Gen 0 | Allocated |
------------------------------------------ |---------- |---------- |---------- |---------- |---------- |------- |---------- |
                       OldStructSerializer | 2.1599 us | 0.0201 us | 2.1340 us | 2.1913 us | 462974.75 | 0.1226 |     652 B |
                       NewStructSerializer | 1.9715 us | 0.0120 us | 1.9572 us | 2.0021 us | 507222.93 | 0.1144 |     664 B |
             OldStructSerializerKnownTypes | 1.8513 us | 0.0046 us | 1.8456 us | 1.8609 us | 540153.52 | 0.0748 |     516 B |
             NewStructSerializerKnownTypes | 1.9560 us | 0.0070 us | 1.9461 us | 1.9732 us | 511259.87 | 0.1144 |     664 B |
 OldStructSerializerKnownTypesReuseSession | 1.6177 us | 0.0152 us | 1.6026 us | 1.6491 us | 618171.67 | 0.0366 |     404 B |
 NewStructSerializerKnownTypesReuseSession | 1.5210 us | 0.0034 us | 1.5138 us | 1.5259 us | 657446.69 | 0.0341 |     416 B |

New struct is around 10% faster, which actually is a little disappointing. I'm probably missing something important here - maybe Marshal methods are slower than expected, or maybe this goal could be achieved by using different technique. @Scooletz would you like to review?