### PR TITLE
Added information about Hyperion/Wire relationship.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Join the chat at https://gitter.im/akkadotnet/Hyperion](https://badges.gitter.im/akkadotnet/Hyperion.svg)](https://gitter.im/akkadotnet/Hyperion?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A high performance polymorphic serializer for the .NET framework.
+A high performance polymorphic serializer for the .NET framework, fork of the [Wire](https://github.com/rogeralsing/Wire) serializer.
+
+Current status: **BETA** (v0.9.2).
 
 ## License
 Licensed under Apache 2.0, see [LICENSE](LICENSE) for the full text.


### PR DESCRIPTION
A simple link to the Wire in the README.md - a name change got some people confused, as they didn't know what to expect from Hyperion.

Also included current status in order to set expectations about API and binary format straight.