### PR TITLE
Use short assembly name during serialization to avoid versioning problems

### DIFF
--- a/Hyperion/ValueSerializers/ObjectSerializer.cs
+++ b/Hyperion/ValueSerializers/ObjectSerializer.cs
@@ -35,7 +35,6 @@ namespace Hyperion.ValueSerializers
                 throw new ArgumentNullException(nameof(type));
 
             Type = type;
-            //TODO: remove version info
             var typeName = type.GetShortAssemblyQualifiedName();
             // ReSharper disable once PossibleNullReferenceException
             // ReSharper disable once AssignNullToNotNullAttribute

--- a/Hyperion/ValueSerializers/TypeSerializer.cs
+++ b/Hyperion/ValueSerializers/TypeSerializer.cs
@@ -66,8 +66,7 @@ namespace Hyperion.ValueSerializers
             if (shortname == null)
                 return null;
 
-            var name = TypeEx.ToQualifiedAssemblyName(shortname);
-            var type = Type.GetType(name,true);
+            var type = TypeEx.GetTypeFromShortName(shortname);
 
             //add the deserialized type to lookup
             if (session.Serializer.Options.PreserveObjectReferences)


### PR DESCRIPTION
The serializer appears to be built to use short names of types, but the code wasn't implemented this way yet.

This patch makes the serializer write the type name as `FullName, Assembly` instead of `FullName, Assembly, Version=..., PublicKey=...`. This fixes issues where deserializer finds a different version of the assembly on the other side.

The reason for this patch is that I'm currently having problems using DistributedPubSub, because Akka.NET depends on a slightly older version of System.Collections.Immutable than some other libraries. As serialized objects carry assembly qualified names, a node with different version of a library throw exceptions trying to decode messages exchanged by the mediator as it cannot find the exact version of the assembly the message was serialized with. 