### PR TITLE
Selectively enable change from PR 28 for net45 compilation, reverting for netstandard1.6 compilation

### DIFF
--- a/Hyperion/Hyperion.csproj
+++ b/Hyperion/Hyperion.csproj
@@ -32,5 +32,9 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/Hyperion/ValueSerializers/TypeSerializer.cs
+++ b/Hyperion/ValueSerializers/TypeSerializer.cs
@@ -66,7 +66,12 @@ namespace Hyperion.ValueSerializers
             if (shortname == null)
                 return null;
 
+#if CORECLR
+            var name = TypeEx.ToQualifiedAssemblyName(shortname);
+            var type = Type.GetType(name, true);
+#else
             var type = TypeEx.GetTypeFromShortName(shortname);
+#endif
 
             //add the deserialized type to lookup
             if (session.Serializer.Options.PreserveObjectReferences)


### PR DESCRIPTION
Due to netstandard1.6 `Type` API changes, needed to restrict changes from PR #28 to only be compiled for the `net45` target, using the code previous to that PR for compilation for `netstandard1.6`.