### PR TITLE
Revert "Use short assembly name during serialization to avoid versioning problems"

### DIFF
--- a/Hyperion/ValueSerializers/ObjectSerializer.cs
+++ b/Hyperion/ValueSerializers/ObjectSerializer.cs
@@ -35,6 +35,7 @@ namespace Hyperion.ValueSerializers
                 throw new ArgumentNullException(nameof(type));
 
             Type = type;
+            //TODO: remove version info
             var typeName = type.GetShortAssemblyQualifiedName();
             // ReSharper disable once PossibleNullReferenceException
             // ReSharper disable once AssignNullToNotNullAttribute

--- a/Hyperion/ValueSerializers/TypeSerializer.cs
+++ b/Hyperion/ValueSerializers/TypeSerializer.cs
@@ -66,7 +66,8 @@ namespace Hyperion.ValueSerializers
             if (shortname == null)
                 return null;
 
-            var type = TypeEx.GetTypeFromShortName(shortname);
+            var name = TypeEx.ToQualifiedAssemblyName(shortname);
+            var type = Type.GetType(name,true);
 
             //add the deserialized type to lookup
             if (session.Serializer.Options.PreserveObjectReferences)


### PR DESCRIPTION
Reverts akkadotnet/Hyperion#28.  During the process of targeting .NET Standard 1.6, we found that the signature being used for `Type.GetType` in this PR isn't available in netstandard1.6.   We made an attempt to use compiler directives to enable this feature for net45 compilation only, but there is the potential for inconsistent wire format across netstandard1.6 and net45 versions of the assembly if we do that.  Plan is to get .NET Core up and running and then come back to making this feature compatible with netstandard1.6.