### PR TITLE
Upgrade dotnet cli to 1.0.0 and Hyperion.Tests.Performance to .NET 4.5.2

### DIFF
--- a/Hyperion.Tests.Performance/Hyperion.Tests.Performance.csproj
+++ b/Hyperion.Tests.Performance/Hyperion.Tests.Performance.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <AssemblyName>Hyperion.Tests.Performance</AssemblyName>
   </PropertyGroup>
 

--- a/Hyperion.sln
+++ b/Hyperion.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hyperion", "Hyperion\Hyperion.csproj", "{7AF8D2B6-9F1F-4A1C-8673-48E533108385}"
 EndProject
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{2F3D4EC4
 	ProjectSection(SolutionItems) = preProject
 		build.cmd = build.cmd
 		build.fsx = build.fsx
+		build.ps1 = build.ps1
 		build.sh = build.sh
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 $FakeVersion = "4.50.0"
 $NBenchVersion = "0.3.4"
 $DotNetChannel = "preview";
-$DotNetVersion = "1.0.0-rc4-004771";
+$DotNetVersion = "1.0.0";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "3.5.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ NUGET_EXE=$TOOLS_DIR/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe
 FAKE_VERSION=4.50.0
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
-DOTNET_VERSION=1.0.0-rc4-004771
+DOTNET_VERSION=1.0.0
 DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
 
 # Define default arguments.


### PR DESCRIPTION
Upgraded .NET Core tooling to newest stable release 1.0.0.  Also upgraded Hyperion.Tests.Performance due to eventual breaking change with NBench 1.0.0 targeting .NET 4.5.2 instead of 4.5.