### PR TITLE
AmbiguousMatchException fix

### DIFF
--- a/Hyperion/SerializerOptions.cs
+++ b/Hyperion/SerializerOptions.cs
@@ -17,7 +17,6 @@ namespace Hyperion
     public class SerializerOptions
     {
         internal static readonly Surrogate[] EmptySurrogates = new Surrogate[0];
-        internal static readonly ValueSerializerFactory[] EmptyValueSerializerFactories = new ValueSerializerFactory[0];
         
 
         private static readonly ValueSerializerFactory[] DefaultValueSerializerFactories =
@@ -60,9 +59,9 @@ namespace Hyperion
             Surrogates = surrogates?.ToArray() ?? EmptySurrogates;
 
             //use the default factories + any user defined
-            ValueSerializerFactories =
-                DefaultValueSerializerFactories.Concat(serializerFactories?.ToArray() ?? EmptyValueSerializerFactories)
-                    .ToArray();
+	        ValueSerializerFactories = serializerFactories == null
+		        ? DefaultValueSerializerFactories
+		        : serializerFactories.Concat(DefaultValueSerializerFactories).ToArray();
 
             KnownTypes = knownTypes?.ToArray() ?? new Type[] {};
             for (var i = 0; i < KnownTypes.Length; i++)


### PR DESCRIPTION
This exception is fired when `ValueSerializerFactory` is registered for some (not direct) descendant of `ICollection`.
Take a look at [this line](https://github.com/akkadotnet/Hyperion/blob/3133431d04281546c71402775fc951540a9cbf7d/Hyperion/SerializerFactories/EnumerableSerializerFactory.cs#L83) - it can't decide which `Add` to use.
Stumbled when tried to serialize Json.Net's `JArray` (don't ask why ¯\\_(ツ)_/¯ ) which is derived from `JCollection` which is derived from `ICollection` and others.
Fix is to place specific `ValueSerializerFactory` at begining in the `Options` prop. I think [this](https://github.com/akkadotnet/Hyperion/blob/dev/Hyperion/SerializerOptions.cs#L35) proofs my assumptions.
