### PR TITLE
Nugetprerelease flag for nightly build naming

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 $FakeVersion = "4.50.0"
 $NBenchVersion = "0.3.4"
 $DotNetChannel = "preview";
-$DotNetVersion = "1.0.0";
+$DotNetVersion = "1.0.4";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "3.5.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"


### PR DESCRIPTION
Add `nugetprerelease=dev` flag and version suffix set to `-beta-123` when publishing nightlies to MyGet feed.