### PR TITLE
Update release notes for v0.9.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 0.9.5 August 11 2017
+
+Provides support for .NET Standard 1.6.
+
+See the full set of changes here: [Hyperion 0.9.5](https://github.com/akkadotnet/Hyperion/milestone/3)
+
 ### 0.9.2 January 05 2017
 Includes bug fixes for immutable data structures and lists.
 

--- a/build.fsx
+++ b/build.fsx
@@ -23,7 +23,7 @@ let outputBinariesNetStandard = outputBinaries @@ "netstandard1.6"
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
-    | "dev" -> "beta" + (if (not (buildNumber = "0")) then ("-" + buildNumber) else "")
+    | "dev" -> (if (not (buildNumber = "0")) then (buildNumber) else "") + "-beta"
     | _ -> ""
 
 Target "Clean" (fun _ ->


### PR DESCRIPTION
Updates release notes for v0.9.5 production release.

Also makes the prerelease numbering `v0.9.5-1-beta` instead of `v0.9.5-beta-1` to account for MyGet feed ordering bug