### PR TITLE
Fixed serialization of exceptions without the default constructor (#64).

### DIFF
--- a/Hyperion.Tests/ExpressionTests.cs
+++ b/Hyperion.Tests/ExpressionTests.cs
@@ -340,6 +340,41 @@ namespace Hyperion.Tests
         }
 
         [Fact]
+        public void CanSerializeTargetInvocationException()
+        {
+            var exc = new TargetInvocationException(null);
+            var serializer = new Hyperion.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(exc, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<TargetInvocationException>(stream);
+                Assert.Equal(exc.Message, deserialized.Message);
+                Assert.Equal(exc.StackTrace, deserialized.StackTrace);
+            }
+        }
+
+        [Fact]
+        public void CanSerializeObjectDisposedException()
+        {
+            var exc = new ObjectDisposedException("Object is already disposed", new ArgumentException("One level deeper"));
+            var serializer = new Hyperion.Serializer();
+
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(exc, stream);
+                stream.Position = 0;
+                var deserialized = serializer.Deserialize<ObjectDisposedException>(stream);
+                Assert.Equal(exc.Message, deserialized.Message);
+                Assert.Equal(exc.StackTrace, deserialized.StackTrace);
+                Assert.Equal(exc.InnerException.GetType(), deserialized.InnerException.GetType());
+                Assert.Equal(exc.InnerException.Message, deserialized.InnerException.Message);
+                Assert.Equal(exc.InnerException.StackTrace, deserialized.InnerException.StackTrace);
+            }
+        }
+
+        [Fact]
         public void CanSerializeCatchBlock()
         {
             var expr = Expression.Catch(typeof(DummyException), Expression.Constant(2));


### PR DESCRIPTION
Using `FormatterServices.GetUninitializedObject` instead of `Activator.CreateInstance` for exception types that don't have a parameterless constructor.

Reflection-based invocation of `GetUninitializedObject` can be removed once the API is exposed in dotnet core API. See this thread for more info: https://github.com/dotnet/corefx/issues/8133