### PR TITLE
Support generic methods in methodinfoserializerfactory

### DIFF
--- a/Hyperion/Extensions/TypeEx.cs
+++ b/Hyperion/Extensions/TypeEx.cs
@@ -223,5 +223,118 @@ namespace Hyperion.Extensions
             var res = shortName.Replace(",%core%", CoreAssemblyName);
             return res;
         }
+
+        /// <summary>
+        /// Search for a method by name, parameter types, and binding flags.  
+        /// Unlike GetMethod(), does 'loose' matching on generic
+        /// parameter types, and searches base interfaces.
+        /// </summary>
+        /// <exception cref="AmbiguousMatchException"/>
+        public static MethodInfo GetMethodExt(this Type thisType,
+                                              string name,
+                                              BindingFlags bindingFlags,
+                                              params Type[] parameterTypes)
+        {
+            MethodInfo matchingMethod = null;
+
+            // Check all methods with the specified name, including in base classes
+            GetMethodExt(ref matchingMethod, thisType, name, bindingFlags, parameterTypes);
+
+            // If we're searching an interface, we have to manually search base interfaces
+            if (matchingMethod == null && thisType.GetTypeInfo().IsInterface)
+            {
+                foreach (Type interfaceType in thisType.GetInterfaces())
+                    GetMethodExt(ref matchingMethod,
+                        interfaceType,
+                        name,
+                        bindingFlags,
+                        parameterTypes);
+            }
+
+            return matchingMethod;
+        }
+
+        private static void GetMethodExt(ref MethodInfo matchingMethod,
+                                         Type type,
+                                         string name,
+                                         BindingFlags bindingFlags,
+                                         params Type[] parameterTypes)
+        {
+            // Check all methods with the specified name, including in base classes
+            foreach (MethodInfo methodInfo in type.GetTypeInfo().GetMember(name,
+                MemberTypes.Method,
+                bindingFlags))
+            {
+                // Check that the parameter counts and types match, 
+                // with 'loose' matching on generic parameters
+                ParameterInfo[] parameterInfos = methodInfo.GetParameters();
+                if (parameterInfos.Length == parameterTypes.Length)
+                {
+                    int i = 0;
+                    for (; i < parameterInfos.Length; ++i)
+                    {
+                        if (!parameterInfos[i].ParameterType
+                                              .IsSimilarType(parameterTypes[i]))
+                            break;
+                    }
+                    if (i == parameterInfos.Length)
+                    {
+                        if (matchingMethod == null)
+                            matchingMethod = methodInfo;
+                        else
+                            throw new AmbiguousMatchException(
+                                "More than one matching method found!");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Special type used to match any generic parameter type in GetMethodExt().
+        /// </summary>
+        public class T
+        { }
+
+        /// <summary>
+        /// Determines if the two types are either identical, or are both generic 
+        /// parameters or generic types with generic parameters in the same
+        ///  locations (generic parameters match any other generic paramter,
+        /// and concrete types).
+        /// </summary>
+        private static bool IsSimilarType(this Type thisType, Type type)
+        {
+            // Ignore any 'ref' types
+            if (thisType.IsByRef)
+                thisType = thisType.GetElementType();
+            if (type.IsByRef)
+                type = type.GetElementType();
+
+            // Handle array types
+            if (thisType.IsArray && type.IsArray)
+                return thisType.GetElementType().IsSimilarType(type.GetElementType());
+
+            // If the types are identical, or they're both generic parameters 
+            // or the special 'T' type, treat as a match
+            if (thisType == type || thisType.IsGenericParameter || thisType == typeof(T) || type.IsGenericParameter || type == typeof(T))
+                return true;
+
+            // Handle any generic arguments
+            if (thisType.GetTypeInfo().IsGenericType && type.GetTypeInfo().IsGenericType)
+            {
+                Type[] thisArguments = thisType.GetGenericArguments();
+                Type[] arguments = type.GetGenericArguments();
+                if (thisArguments.Length == arguments.Length)
+                {
+                    for (int i = 0; i < thisArguments.Length; ++i)
+                    {
+                        if (!thisArguments[i].IsSimilarType(arguments[i]))
+                            return false;
+                    }
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Attempts to fix #77  by supporting serialization of closed constructed generic methodinfos. 

Makes use of a more relaxed GetMethod implementation (defined in `TypeEx`) that will match closed constructed methods to generic method definitions in a sensible way.

FYI, I don't have FSharp on this machine so have not checked that those tests still work.