### PR TITLE
Added support for DateTimeOffset as a primitive

### DIFF
--- a/Hyperion.PerfTest/Program.cs
+++ b/Hyperion.PerfTest/Program.cs
@@ -35,8 +35,12 @@ namespace Hyperion.PerfTest
 
             var guidTest = new GuidTest();
             guidTest.Run(1000000);
+
+            var dateTimeOffsetTest = new DateTimeOffsetTest();
+            dateTimeOffsetTest.Run(1000000);
+
             var typicalPersonArrayTest = new TypicalPersonArrayTest();
-            typicalPersonArrayTest.Run(1000);
+            typicalPersonArrayTest.Run(1000);           
 
             var typicalPersonTest = new TypicalPersonTest();
             typicalPersonTest.Run(100000);

--- a/Hyperion.PerfTest/Tests/DateTimeOffsetTest.cs
+++ b/Hyperion.PerfTest/Tests/DateTimeOffsetTest.cs
@@ -1,0 +1,21 @@
+﻿#region copyright
+// -----------------------------------------------------------------------
+//  <copyright file="GuidTest.cs" company="Akka.NET Team">
+//      Copyright (C) 2015-2016 AsynkronIT <https://github.com/AsynkronIT>
+//      Copyright (C) 2016-2016 Akka.NET Team <https://github.com/akkadotnet>
+//  </copyright>
+// -----------------------------------------------------------------------
+#endregion
+
+using System;
+
+namespace Hyperion.PerfTest.Tests
+{
+    class DateTimeOffsetTest : TestBase<DateTimeOffset>
+    {
+        protected override DateTimeOffset GetValue()
+        {
+            return DateTimeOffset.Now;
+        }
+    }
+}

--- a/Hyperion.PerfTest/Tests/DateTimeOffsetTest.cs
+++ b/Hyperion.PerfTest/Tests/DateTimeOffsetTest.cs
@@ -1,6 +1,6 @@
 ﻿#region copyright
 // -----------------------------------------------------------------------
-//  <copyright file="GuidTest.cs" company="Akka.NET Team">
+//  <copyright file="DateTimeOffsetTest.cs" company="Akka.NET Team">
 //      Copyright (C) 2015-2016 AsynkronIT <https://github.com/AsynkronIT>
 //      Copyright (C) 2016-2016 Akka.NET Team <https://github.com/akkadotnet>
 //  </copyright>

--- a/Hyperion.Tests/PrimitivesTests.cs
+++ b/Hyperion.Tests/PrimitivesTests.cs
@@ -76,9 +76,27 @@ namespace Hyperion.Tests
         }
 
         [Fact]
-        public void CanSerializeDateTime()
+        public void CanSerializeDateTimeUtc()
         {
             SerializeAndAssert(DateTime.UtcNow);
+        }
+
+        [Fact]
+        public void CanSerializeDateTimeLocal()
+        {
+            SerializeAndAssert(new DateTime(DateTime.Now.Ticks, DateTimeKind.Local));
+        }
+
+        [Fact]
+        public void CanSerializeDateTimeOffsetNow()
+        {
+            SerializeAndAssert(DateTimeOffset.Now);
+        }
+
+        [Fact]
+        public void CanSerializeDateTimeOffsetUtc()
+        {
+            SerializeAndAssert(DateTimeOffset.UtcNow);
         }
 
         [Fact]

--- a/Hyperion/Extensions/TypeEx.cs
+++ b/Hyperion/Extensions/TypeEx.cs
@@ -35,6 +35,7 @@ namespace Hyperion.Extensions
         public static readonly Type SByteType = typeof(sbyte);
         public static readonly Type BoolType = typeof(bool);
         public static readonly Type DateTimeType = typeof(DateTime);
+        public static readonly Type DateTimeOffsetType = typeof(DateTimeOffset);
         public static readonly Type StringType = typeof(string);
         public static readonly Type GuidType = typeof(Guid);
         public static readonly Type FloatType = typeof(float);
@@ -56,6 +57,7 @@ namespace Hyperion.Extensions
                    type == ByteType ||
                    type == SByteType ||
                    type == DateTimeType ||
+                   type == DateTimeOffsetType ||
                    type == BoolType ||
                    type == StringType ||
                    type == GuidType ||

--- a/Hyperion/NoAllocBitConverter.cs
+++ b/Hyperion/NoAllocBitConverter.cs
@@ -112,5 +112,15 @@ namespace Hyperion
                 *((long*) b) = dateTime.Ticks;
             bytes[DateTimeSerializer.Size - 1] = (byte) dateTime.Kind;
         }
+
+        public static unsafe void GetBytes(DateTimeOffset dateTime, byte[] bytes)
+        {
+            //datetime size is 9 ticks + kind
+            fixed (byte* b = bytes)
+            {
+                *((long*)b) = dateTime.Ticks;
+                *((short*) (b + sizeof(long))) = (short)dateTime.Offset.TotalMinutes;
+            }
+        }
     }
 }

--- a/Hyperion/NoAllocBitConverter.cs
+++ b/Hyperion/NoAllocBitConverter.cs
@@ -115,7 +115,7 @@ namespace Hyperion
 
         public static unsafe void GetBytes(DateTimeOffset dateTime, byte[] bytes)
         {
-            //datetime size is 9 ticks + kind
+            //datetimeoffset size is 10 ticks + offset
             fixed (byte* b = bytes)
             {
                 *((long*)b) = dateTime.Ticks;

--- a/Hyperion/NoAllocBitConverter.cs
+++ b/Hyperion/NoAllocBitConverter.cs
@@ -115,11 +115,11 @@ namespace Hyperion
 
         public static unsafe void GetBytes(DateTimeOffset dateTime, byte[] bytes)
         {
-            //datetimeoffset size is 10 ticks + offset
+            //datetimeoffset size is 16 ticks + offset
             fixed (byte* b = bytes)
             {
                 *((long*)b) = dateTime.Ticks;
-                *((short*) (b + sizeof(long))) = (short)dateTime.Offset.TotalMinutes;
+                *((long*)(b + sizeof(long))) = (long)dateTime.Offset.Ticks;
             }
         }
     }

--- a/Hyperion/Serializer.cs
+++ b/Hyperion/Serializer.cs
@@ -58,7 +58,7 @@ namespace Hyperion
             _deserializerLookup[StringSerializer.Manifest] = StringSerializer.Instance;
             _deserializerLookup[Int32Serializer.Manifest] = Int32Serializer.Instance;
             _deserializerLookup[ByteArraySerializer.Manifest] = ByteArraySerializer.Instance;
-            //10 not yet used
+            _deserializerLookup[DateTimeOffsetSerializer.Manifest] = DateTimeOffsetSerializer.Instance;
             _deserializerLookup[GuidSerializer.Manifest] = GuidSerializer.Instance;
             _deserializerLookup[FloatSerializer.Manifest] = FloatSerializer.Instance;
             _deserializerLookup[DoubleSerializer.Manifest] = DoubleSerializer.Instance;
@@ -96,6 +96,7 @@ namespace Hyperion
             AddValueSerializer<char>(CharSerializer.Instance);
             AddValueSerializer<byte[]>(ByteArraySerializer.Instance);
             AddValueSerializer<DateTime>(DateTimeSerializer.Instance);
+            AddValueSerializer<DateTimeOffset>(DateTimeOffsetSerializer.Instance);
 
             AddValueSerializer<Type>(TypeSerializer.Instance);
             AddValueSerializer(TypeSerializer.Instance, TypeEx.RuntimeType);

--- a/Hyperion/ValueSerializers/DateTimeOffsetSerializer.cs
+++ b/Hyperion/ValueSerializers/DateTimeOffsetSerializer.cs
@@ -15,7 +15,7 @@ namespace Hyperion.ValueSerializers
     public class DateTimeOffsetSerializer : SessionAwareByteArrayRequiringValueSerializer<DateTimeOffset>
     {
         public const byte Manifest = 10;
-        public const int Size = sizeof(long) + sizeof(short);
+        public const int Size = sizeof(long) + sizeof(long);
         public static readonly DateTimeOffsetSerializer Instance = new DateTimeOffsetSerializer();
 
         public DateTimeOffsetSerializer() : base(Manifest, () => WriteValueImpl, () => ReadValueImpl)
@@ -37,9 +37,9 @@ namespace Hyperion.ValueSerializers
         private static DateTimeOffset ReadDateTimeOffset(Stream stream, byte[] bytes)
         {
             stream.Read(bytes, 0, Size);
-            var ticks = BitConverter.ToInt64(bytes, 0);
-            var minutes = BitConverter.ToInt16(bytes, sizeof(long));
-            var dateTimeOffset = new DateTimeOffset(ticks, TimeSpan.FromMinutes(minutes));
+            var dateTimeTicks = BitConverter.ToInt64(bytes, 0);
+            var offsetTicks = BitConverter.ToInt64(bytes, sizeof(long));
+            var dateTimeOffset = new DateTimeOffset(dateTimeTicks, TimeSpan.FromTicks(offsetTicks));
             return dateTimeOffset;
         }
 

--- a/Hyperion/ValueSerializers/DateTimeOffsetSerializer.cs
+++ b/Hyperion/ValueSerializers/DateTimeOffsetSerializer.cs
@@ -1,0 +1,48 @@
+#region copyright
+// -----------------------------------------------------------------------
+//  <copyright file="DateTimeSerializer.cs" company="Akka.NET Team">
+//      Copyright (C) 2015-2016 AsynkronIT <https://github.com/AsynkronIT>
+//      Copyright (C) 2016-2016 Akka.NET Team <https://github.com/akkadotnet>
+//  </copyright>
+// -----------------------------------------------------------------------
+#endregion
+
+using System;
+using System.IO;
+
+namespace Hyperion.ValueSerializers
+{
+    public class DateTimeOffsetSerializer : SessionAwareByteArrayRequiringValueSerializer<DateTimeOffset>
+    {
+        public const byte Manifest = 10;
+        public const int Size = sizeof(long) + sizeof(short);
+        public static readonly DateTimeOffsetSerializer Instance = new DateTimeOffsetSerializer();
+
+        public DateTimeOffsetSerializer() : base(Manifest, () => WriteValueImpl, () => ReadValueImpl)
+        {
+        }
+
+        private static void WriteValueImpl(Stream stream, DateTimeOffset dateTimeOffset, byte[] bytes)
+        {
+            NoAllocBitConverter.GetBytes(dateTimeOffset, bytes);
+            stream.Write(bytes, 0, Size);
+        }
+
+        public static DateTimeOffset ReadValueImpl(Stream stream, byte[] bytes)
+        {
+            var dateTime = ReadDateTimeOffset(stream, bytes);
+            return dateTime;
+        }
+
+        private static DateTimeOffset ReadDateTimeOffset(Stream stream, byte[] bytes)
+        {
+            stream.Read(bytes, 0, Size);
+            var ticks = BitConverter.ToInt64(bytes, 0);
+            var minutes = BitConverter.ToInt16(bytes, sizeof(long));
+            var dateTimeOffset = new DateTimeOffset(ticks, TimeSpan.FromMinutes(minutes));
+            return dateTimeOffset;
+        }
+
+        public override int PreallocatedByteBufferSize => Size;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hyperion was designed to safely transfer messages in distributed systems, for ex
 In message based systems, it is common to receive different types of messages and apply pattern matching over those messages.
 If the messages does not carry over all the relevant type information to the receiveing side, the message might no longer match exactly what your system expect.
 
-Consilder the following case:
+Consider the following case:
 
 ```csharp
 public class Envelope


### PR DESCRIPTION
Handles DateTimeOffset as a primitive, the same way as DateTime is currently handled. It serializes the offset in minutes, instead of DateTimeKind. The offset can be +/- 720 minutes, so a signed short has been used.
