### PR TITLE
Introduced PreserveReferencesAttribute

### DIFF
--- a/Hyperion.Tests/PreserveObjectReferencesTests.cs
+++ b/Hyperion.Tests/PreserveObjectReferencesTests.cs
@@ -1,0 +1,148 @@
+﻿#region copyright
+// -----------------------------------------------------------------------
+//  <copyright file="TestBase.cs" company="Akka.NET Team">
+//      Copyright (C) 2015-2016 AsynkronIT <https://github.com/AsynkronIT>
+//      Copyright (C) 2016-2016 Akka.NET Team <https://github.com/akkadotnet>
+//  </copyright>
+// -----------------------------------------------------------------------
+#endregion
+
+using System;
+using Xunit;
+
+namespace Hyperion.Tests
+{
+    public class LocalPreserveObjectReferencesTests : TestBase
+    {
+        private readonly SerializerSession _serializerSession;
+        private readonly DeserializerSession _deserializerSession;
+
+        public LocalPreserveObjectReferencesTests() : base(new SerializerOptions(preserveObjectReferences: false))
+        {
+            _serializerSession = new SerializerSession(Serializer);
+            _deserializerSession = new DeserializerSession(Serializer);
+        }
+
+        [Fact]
+        public void PreserveReferencesAttributeShouldOverrideSerializerOptions()
+        {
+            var source = new PreservedObject { First = "first", Second = 123 };
+            Serialize(source, _serializerSession);
+            Reset();
+            var actual1 = Deserialize<PreservedObject>(_deserializerSession);
+
+            Assert.Equal(source, actual1);
+
+            Serialize(source, _serializerSession);
+            Reset();
+            var actual2 = Deserialize<PreservedObject>(_deserializerSession);
+
+            Assert.Equal(source, actual2);
+        }
+    }
+
+    public class GlobalPreserveObjectReferencesTests : TestBase
+    {
+        private readonly SerializerSession _serializerSession;
+        private readonly DeserializerSession _deserializerSession;
+
+        public GlobalPreserveObjectReferencesTests() : base(new SerializerOptions(preserveObjectReferences: true))
+        {
+            _serializerSession = new SerializerSession(Serializer);
+            _deserializerSession = new DeserializerSession(Serializer);
+        }
+
+        [Fact]
+        public void PreserveObjectReferencesShouldWorkInSessionScope()
+        {
+            var source = new Something { Int32Prop = 123, StringProp = "hello" };
+            Serialize(source, _serializerSession);
+            Reset();
+            var actual1 = Deserialize<Something>(_deserializerSession);
+
+            Assert.Equal(source, actual1);
+
+            Serialize(source, _serializerSession);
+            Reset();
+            var actual2 = Deserialize<Something>(_deserializerSession);
+
+            Assert.Equal(source, actual2);
+        }
+
+        [Fact]
+        public void PreserveReferencesAttributeShouldOverrideSerializerOptions()
+        {
+            var source = new UnpreservedObject { First = "first", Second = 123 };
+            Serialize(source, _serializerSession);
+            Reset();
+            var actual1 = Deserialize<UnpreservedObject>(_deserializerSession);
+
+            Assert.Equal(source, actual1);
+
+            Serialize(source, _serializerSession);
+            Reset();
+            var actual2 = Deserialize<UnpreservedObject>(_deserializerSession);
+
+            Assert.Equal(source, actual2);
+        }
+    }
+
+    [PreserveReferences]
+    public sealed class PreservedObject : IEquatable<PreservedObject>
+    {
+        public string First { get; set; }
+        public int Second { get; set; }
+
+        public bool Equals(PreservedObject other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(First, other.First) && Second == other.Second;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is PreservedObject && Equals((PreservedObject) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((First != null ? First.GetHashCode() : 0) * 397) ^ Second;
+            }
+        }
+    }
+
+    [PreserveReferences(false)]
+    public sealed class UnpreservedObject : IEquatable<UnpreservedObject>
+    {
+        public string First { get; set; }
+        public int Second { get; set; }
+
+        public bool Equals(UnpreservedObject other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(First, other.First) && Second == other.Second;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is UnpreservedObject && Equals((UnpreservedObject) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((First != null ? First.GetHashCode() : 0) * 397) ^ Second;
+            }
+        }
+    }
+
+}

--- a/Hyperion.Tests/TestBase.cs
+++ b/Hyperion.Tests/TestBase.cs
@@ -14,18 +14,24 @@ namespace Hyperion.Tests
 {
     public abstract class TestBase
     {
-        private Serializer _serializer;
+        protected Serializer Serializer;
         private readonly MemoryStream _stream;
+
+        protected TestBase(SerializerOptions options)
+        {
+            Serializer = new Serializer(options);
+            _stream = new MemoryStream();
+        }
 
         protected TestBase()
         {
-            _serializer = new Serializer();
+            Serializer = new Serializer();
             _stream = new MemoryStream();
         }
 
         protected void CustomInit(Serializer serializer)
         {
-            _serializer = serializer;
+            Serializer = serializer;
         }
 
 
@@ -36,12 +42,22 @@ namespace Hyperion.Tests
 
         public void Serialize(object o)
         {
-            _serializer.Serialize(o, _stream);
+            Serializer.Serialize(o, _stream);
+        }
+
+        public void Serialize(object o, SerializerSession session)
+        {
+            Serializer.Serialize(o, _stream, session);
         }
 
         public T Deserialize<T>()
         {
-            return _serializer.Deserialize<T>(_stream);
+            return Serializer.Deserialize<T>(_stream);
+        }
+
+        public T Deserialize<T>(DeserializerSession session)
+        {
+            return Serializer.Deserialize<T>(_stream, session);
         }
 
         public void AssertMemoryStreamConsumed()

--- a/Hyperion/Attributes.cs
+++ b/Hyperion/Attributes.cs
@@ -1,0 +1,32 @@
+﻿#region copyright
+// -----------------------------------------------------------------------
+//  <copyright file="Serializer.cs" company="Akka.NET Team">
+//      Copyright (C) 2015-2016 AsynkronIT <https://github.com/AsynkronIT>
+//      Copyright (C) 2016-2016 Akka.NET Team <https://github.com/akkadotnet>
+//  </copyright>
+// -----------------------------------------------------------------------
+#endregion
+
+using System;
+
+namespace Hyperion
+{
+    public abstract class HyperionAttribute : Attribute { }
+
+    /// <summary>
+    /// Mark class with this attribute in order to turn preserving all of its object references
+    /// in scope of a single <see cref="SerializerSession"/> / <see cref="DeserializerSession"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class PreserveReferencesAttribute : HyperionAttribute
+    {
+        public PreserveReferencesAttribute() : this(true) { }
+
+        public PreserveReferencesAttribute(bool enabled)
+        {
+            Enabled = enabled;
+        }
+
+        public bool Enabled { get; }
+    }
+}

--- a/Hyperion/Extensions/TypeEx.cs
+++ b/Hyperion/Extensions/TypeEx.cs
@@ -100,6 +100,11 @@ namespace Hyperion.Extensions
             return type.IsArray && type.GetArrayRank() == 1 && type.GetElementType().IsHyperionPrimitive();
         }
 
+        public static HyperionAttribute[] GetHyperionAttributes(this Type type)
+        {
+            return type.GetTypeInfo().GetCustomAttributes<HyperionAttribute>().ToArray();
+        }
+
         private static readonly ConcurrentDictionary<ByteArrayKey, Type> TypeNameLookup =
             new ConcurrentDictionary<ByteArrayKey, Type>(ByteArrayKeyComparer.Instance);
 

--- a/Hyperion/ValueSerializers/ObjectSerializer.cs
+++ b/Hyperion/ValueSerializers/ObjectSerializer.cs
@@ -29,12 +29,19 @@ namespace Hyperion.ValueSerializers
         private ObjectWriter _writer;
         int _preallocatedBufferSize;
 
+        public bool? PreserveObjectReferences { get; }
+
         public ObjectSerializer(Type type)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
 
             Type = type;
+            
+            var attributes = type.GetHyperionAttributes();
+            foreach (var attribute in attributes)
+                if (attribute is PreserveReferencesAttribute p) PreserveObjectReferences = p.Enabled;
+
             //TODO: remove version info
             var typeName = type.GetShortAssemblyQualifiedName();
             // ReSharper disable once PossibleNullReferenceException


### PR DESCRIPTION
At this moment Hyperion defines an ability to preserve (and optimize serialization of) references for all reference types at a serializer level. There's no way to tell "I want to use this optimization, but only for objects of given type", which could be useful for things like i.e. Akka.NET `IActorRef` (if we'll use serializer sessions properly).

This PR introduces `PreserveReferencesAttribute`, which can be marked on class level. All objects with this attribute will override default `SerializerOptions.PreserveObjectReferences` settings.