### PR TITLE
v0.9.8 production release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+### 0.9.8 January 31 2018 ####
+**Maintenance release for Hyperion v0.9.***
+This small patch conists of the following bug fixes to Hyperion v0.9.* branch:
+
+* [Support for FSharpSet<T>](https://github.com/akkadotnet/Hyperion/pull/92)
+
 ### 0.9.7 January 18 2018 ####
 **Maintenance release for Hyperion v0.9.***
 

--- a/src/Hyperion.Tests/FSharpTests.cs
+++ b/src/Hyperion.Tests/FSharpTests.cs
@@ -45,6 +45,16 @@ namespace Hyperion.Tests
         }
 
         [Fact]
+        public void CanSerializeFSharpSet()
+        {
+            var expected = SetModule.OfArray(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+            Serialize(expected);
+            Reset();
+            var actual = Deserialize<object>();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void CanSerializeSimpleDU()
         {
             var expected = DU1.NewA(1);

--- a/src/Hyperion/SerializerFactories/EnumerableSerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/EnumerableSerializerFactory.cs
@@ -139,7 +139,7 @@ namespace Hyperion.SerializerFactories
 
             Func<object, int> countGetter = o => (int)countProperty.GetValue(o);
             ObjectReader reader = null;
-            if (addMethod != null)
+            if (HasParameterlessConstructor(type) && addMethod != null)
             {
                 var add = CompileMethodToDelegate(addMethod, type, elementType);
                 reader = (stream, session) =>

--- a/src/common.props
+++ b/src/common.props
@@ -2,13 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2016-2017 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.9.7</VersionPrefix>
-    <PackageReleaseNotes>Maintenance release for Hyperion v0.9.0**
-This patch mostly contains bugfixes and enhancements to the existing Hyperion v0.9.* branch. No major API changes have been made.
-[EnumerableSerializeFactory fixes](https://github.com/akkadotnet/Hyperion/pull/81)
-[Fix: ObjectDisposedException cannot be deserialized](https://github.com/akkadotnet/Hyperion/issues/64)
-[Added support for DateTimeOffset as a primitive](https://github.com/akkadotnet/Hyperion/pull/79)
-You can [see the full set of changes for Hyperion v0.9.7 here](https://github.com/akkadotnet/Hyperion/milestone/5).</PackageReleaseNotes>
+    <VersionPrefix>0.9.8</VersionPrefix>
+    <PackageReleaseNotes>Maintenance release for Hyperion v0.9.***
+This small patch conists of the following bug fixes to Hyperion v0.9.*:
+[Support for FSharpSet&lt;T&gt;](https://github.com/akkadotnet/Hyperion/pull/92)</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Hyperion</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Hyperion/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
### 0.9.8 January 31 2018 ####
**Maintenance release for Hyperion v0.9.***
This small patch conists of the following bug fixes to Hyperion v0.9.* branch:

* [Support for FSharpSet<T>](https://github.com/akkadotnet/Hyperion/pull/92)