### PR TITLE
preserve reference is checking type to prevent InvalidCastException

### DIFF
--- a/src/Hyperion.Tests/Bugs.cs
+++ b/src/Hyperion.Tests/Bugs.cs
@@ -126,6 +126,21 @@ namespace Hyperion.Tests
             }
         }
 
+        [Fact]
+        public void CanSerializeUri()
+        {
+            var stream = new MemoryStream();
+            var msg = new Uri("http://localhost:9202/", UriKind.RelativeOrAbsolute);
+            var serializer = new Serializer(new SerializerOptions(preserveObjectReferences: true, versionTolerance: true));
+            serializer.Serialize(msg, stream);
+            stream.Position = 0;
+            var res = serializer.Deserialize(stream);
+
+            Assert.Equal(msg, res);
+            Assert.Equal(stream.Length, stream.Position);
+        }
+
+
         public class SnapshotSelectionCriteria
         {
             public static SnapshotSelectionCriteria Latest { get; set; } = new SnapshotSelectionCriteria()

--- a/src/Hyperion/SerializerSession.cs
+++ b/src/Hyperion/SerializerSession.cs
@@ -12,6 +12,26 @@ using System.Collections.Generic;
 
 namespace Hyperion
 {
+    internal class TypedEqualityComparer : IEqualityComparer<object>
+    {
+        public static readonly TypedEqualityComparer Instance = new TypedEqualityComparer();
+        public new bool Equals(object x, object y)
+        {
+            if (EqualityComparer<object>.Default.Equals(x, y))
+            {
+                if (x != null && y != null)
+                    return x.GetType().Equals(y.GetType());
+                return true;
+            }
+            return false;
+        }
+
+        public int GetHashCode(object obj)
+        {
+            return EqualityComparer<object>.Default.GetHashCode(obj);
+        }
+    }
+
     public class SerializerSession
     {
         public const int MinBufferSize = 9;
@@ -28,9 +48,9 @@ namespace Hyperion
             Serializer = serializer;
             if (serializer.Options.PreserveObjectReferences)
             {
-                _objects = new Dictionary<object, int>();
+                _objects = new Dictionary<object, int>(TypedEqualityComparer.Instance);
             }
-            _nextTypeId = (ushort)(serializer.Options.KnownTypes.Length );
+            _nextTypeId = (ushort)(serializer.Options.KnownTypes.Length);
         }
 
         public void TrackSerializedObject(object obj)
@@ -60,7 +80,7 @@ namespace Hyperion
             if (length <= _buffer.Length)
                 return _buffer;
 
-            length = Math.Max(length, _buffer.Length*2);
+            length = Math.Max(length, _buffer.Length * 2);
 
             _buffer = new byte[length];
 


### PR DESCRIPTION
fixes #96 

not sure if the `TypedEqualityComparer` can be improved