### PR TITLE
made it easier to generate beta packages of Hyperion locally

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -16,7 +16,7 @@ let configuration = "Release"
 // Read release notes and version
 let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynamically look up the solution
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
-let preReleaseVersionSuffix = (if (not (buildNumber = "0")) then (buildNumber) else "") + "-beta"
+let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString()) 
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix

--- a/src/common.props
+++ b/src/common.props
@@ -4,7 +4,7 @@
     <Authors>Akka.NET Team</Authors>
     <VersionPrefix>0.9.8</VersionPrefix>
     <PackageReleaseNotes>Maintenance release for Hyperion v0.9.***
-This small patch conists of the following bug fixes to Hyperion v0.9.*:
+This small patch conists of the following bug fixes to Hyperion v0.9.* branch:
 [Support for FSharpSet&lt;T&gt;](https://github.com/akkadotnet/Hyperion/pull/92)</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Hyperion</PackageProjectUrl>


### PR DESCRIPTION
If TeamCity isn't available to pass in a build number environment variable, beta NuGet packages will now be named using the following convention:

```
[PackageName].[VerisonInReleaseNotes]-beta[DateTime.UtcNow.Ticks]
```

If the `BUILD_NUMBER` environment variable is available, NuGet packages will be built the same way they are now:

```
[PackageName].[VerisonInReleaseNotes]-beta[BUILD_NUMBER]
```