### PR TITLE
Proposed fix to support DotNet Core 3 preview 4 (#111)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ Param(
 $FakeVersion = "4.61.2"
 $NBenchVersion = "1.0.1"
 $DotNetChannel = "LTS";
-$DotNetVersion = "2.0.0";
+$DotNetVersion = "2.2.107";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVersion/scripts/obtain/dotnet-install.ps1";
 $NugetVersion = "4.1.0";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/v$NugetVersion/nuget.exe"

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ NUGET_EXE=$TOOLS_DIR/nuget.exe
 NUGET_URL=https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe
 FAKE_VERSION=4.61.2
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
-DOTNET_VERSION=2.0.3
+DOTNET_VERSION=2.2.107
 DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v$DOTNET_VERSION/scripts/obtain/dotnet-install.sh
 
 # Define default arguments.

--- a/src/Hyperion.Benchmarks/Hyperion.Benchmarks.csproj
+++ b/src/Hyperion.Benchmarks/Hyperion.Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Hyperion.Tests.FSharpData/Hyperion.Tests.FSharpData.fsproj
+++ b/src/Hyperion.Tests.FSharpData/Hyperion.Tests.FSharpData.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hyperion.Tests/Hyperion.Tests.csproj
+++ b/src/Hyperion.Tests/Hyperion.Tests.csproj
@@ -2,8 +2,8 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
-    <!--<RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>-->
+    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp2.2;</TargetFrameworks>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hyperion.Tests/Hyperion.Tests.csproj
+++ b/src/Hyperion.Tests/Hyperion.Tests.csproj
@@ -2,8 +2,8 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
-    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
+    <TargetFrameworks>net461;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <!--<RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hyperion.Tests/Hyperion.Tests.csproj
+++ b/src/Hyperion.Tests/Hyperion.Tests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 

--- a/src/Hyperion.Tests/Hyperion.Tests.csproj
+++ b/src/Hyperion.Tests/Hyperion.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp2.2;</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.2;</TargetFrameworks>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 

--- a/src/Hyperion/Compilation/ExpressionEx.cs
+++ b/src/Hyperion/Compilation/ExpressionEx.cs
@@ -29,7 +29,7 @@ namespace Hyperion.Compilation
                 var convert = Expression.Convert(x, typeof(object));
                 return convert;
             }
-#if SERIALIZATION
+#if !NETSTANDARD1_6
             var defaultCtor = type.GetTypeInfo().GetConstructor(new Type[] { });
             var il = defaultCtor?.GetMethodBody()?.GetILAsByteArray();
             var sideEffectFreeCtor = il != null && il.Length <= 8; //this is the size of an empty ctor

--- a/src/Hyperion/Extensions/ReflectionEx.cs
+++ b/src/Hyperion/Extensions/ReflectionEx.cs
@@ -12,10 +12,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-#if SERIALIZATION
-
-#endif
-
 namespace Hyperion.Extensions
 {
     internal static class BindingFlagsEx
@@ -40,7 +36,7 @@ namespace Hyperion.Extensions
                     current
                         .GetTypeInfo()
                         .GetFields(BindingFlagsEx.All)
-#if SERIALIZATION
+#if !NETSTANDARD1_6
                         .Where(f => !f.IsDefined(typeof(NonSerializedAttribute)))
 #endif
                         .Where(f => !f.IsDefined(typeof(IgnoreAttribute)))

--- a/src/Hyperion/Extensions/TypeEx.cs
+++ b/src/Hyperion/Extensions/TypeEx.cs
@@ -15,10 +15,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
-#if SERIALIZATION
-using System.Runtime.Serialization;
-#endif
-
 namespace Hyperion.Extensions
 {
     internal static class TypeEx
@@ -70,7 +66,7 @@ namespace Hyperion.Extensions
             //add TypeSerializer with null support
         }
 
-#if !SERIALIZATION
+#if NETSTANDARD1_6
     //HACK: the GetUnitializedObject actually exists in .NET Core, its just not public
         private static readonly Func<Type, object> getUninitializedObjectDelegate = (Func<Type, object>)
             typeof(string)
@@ -88,7 +84,7 @@ namespace Hyperion.Extensions
 #else
         public static object GetEmptyObject(this Type type)
         {
-            return FormatterServices.GetUninitializedObject(type);
+            return System.Runtime.Serialization.FormatterServices.GetUninitializedObject(type);
         }
 #endif
 

--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyTitle>Hyperion</AssemblyTitle>
     <Description>Hyperion, fast binary POCO serializer</Description>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net452</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>serialization;poco</PackageTags>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
@@ -24,12 +24,12 @@
     <DefineConstants>$(DefineConstants);SERIALIZATION;</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);SERIALIZATION;UNSAFE;NET45</DefineConstants>
   </PropertyGroup>
 

--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -20,6 +20,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);SERIALIZATION;</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -4,13 +4,18 @@
   <PropertyGroup>
     <AssemblyTitle>Hyperion</AssemblyTitle>
     <Description>Hyperion, fast binary POCO serializer</Description>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>serialization;poco</PackageTags>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>

--- a/src/Hyperion/SerializerFactories/ExceptionSerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/ExceptionSerializerFactory.cs
@@ -38,11 +38,16 @@ namespace Hyperion.SerializerFactories
         public override bool CanDeserialize(Serializer serializer, Type type) => CanSerialize(serializer, type);
 
         // Workaround for CoreCLR where FormatterServices.GetUninitializedObject is not public
+#if NETSTANDARD1_6
         private static readonly Func<Type, object> GetUninitializedObject =
-            (Func<Type, object>)
+            (Func<Type, object>) 
                 typeof(string).GetTypeInfo().Assembly.GetType("System.Runtime.Serialization.FormatterServices")
                     .GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
                     .CreateDelegate(typeof(Func<Type, object>));
+#else
+        private static readonly Func<Type, object> GetUninitializedObject =
+            System.Runtime.Serialization.FormatterServices.GetUninitializedObject;
+#endif
 
         public override ValueSerializer BuildSerializer(Serializer serializer, Type type,
             ConcurrentDictionary<Type, ValueSerializer> typeMapping)

--- a/src/Hyperion/SerializerFactories/ExceptionSerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/ExceptionSerializerFactory.cs
@@ -65,7 +65,13 @@ namespace Hyperion.SerializerFactories
                 var stackTraceString = stream.ReadString(session);
                 var innerException = stream.ReadObject(session);
 
-                _className.SetValue(exception,className);
+                // CoreFX 3.0 has changed the underlying implementation of Exception to
+                // simply use GetType().ToString() and no longer has a _className field.
+                // See: https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/Exception.cs
+                if (_className != null)
+                {
+                    _className.SetValue(exception, className);
+                }
                 _message.SetValue(exception, message);
                 _remoteStackTraceString.SetValue(exception, remoteStackTraceString);
                 _stackTraceString.SetValue(exception, stackTraceString);
@@ -73,7 +79,13 @@ namespace Hyperion.SerializerFactories
                 return exception;
             }, (stream, exception, session) =>
             {
-                var className = (string)_className.GetValue(exception);
+                // CoreFX 3.0 has changed the underlying implementation of Exception to
+                // simply use GetType().ToString() and no longer has a _className field.
+                // See: https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/System/Exception.cs
+                var className = _className != null
+                    ? (string) _className.GetValue(exception)
+                    : exception.GetType().ToString();
+
                 var message = (string)_message.GetValue(exception);
                 var remoteStackTraceString = (string)_remoteStackTraceString.GetValue(exception);
                 var stackTraceString = (string)_stackTraceString.GetValue(exception);

--- a/src/Hyperion/SerializerFactories/ISerializableSerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/ISerializableSerializerFactory.cs
@@ -6,7 +6,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 #endregion
-#if SERIALIZATION
+#if !NETSTANDARD1_6
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Hyperion/SerializerOptions.cs
+++ b/src/Hyperion/SerializerOptions.cs
@@ -39,7 +39,7 @@ namespace Hyperion
             new DictionarySerializerFactory(),
             new ArraySerializerFactory(),
             new MultipleDimensionalArraySerialzierFactory(),
-#if SERIALIZATION
+#if !NETSTANDARD1_6
             new ISerializableSerializerFactory(), //TODO: this will mess up the indexes in the serializer payload
 #endif
             new EnumerableSerializerFactory(),

--- a/src/common.props
+++ b/src/common.props
@@ -11,6 +11,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.3.0</XunitVersion>
-    <TestSdkVersion>15.3.0</TestSdkVersion>
+    <TestSdkVersion>16.1.0</TestSdkVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is my proposed starting point for supporting DotNet Core 3.0 (at least the preview release 4).

It appears that the location of the System.Runtime.Serialization.FormatterServices class has been moved and the GetUninitializedObject made public again.

I'm proposing that a netstandard2.0 target be added so that the original CoreCLR workaround is compiled for netstandard1.6, but that netstandard2.0 and net45 reference the public member directly.