### PR TITLE
Build system update

### DIFF
--- a/build-system/README.md
+++ b/build-system/README.md
@@ -1,0 +1,7 @@
+# Azure Pipelines Build Files
+These `.yaml` files are used by Windows Azure DevOps Pipelines to help execute the following types of builds:
+
+- Pull request validation on Linux (Mono / .NET Core)
+- Pull request validation on Windows (.NET Framework / .NET Core)
+- NuGet releases with automatic release notes posted to a Github Release repository.
+

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -1,0 +1,55 @@
+parameters:
+  name: ''
+  vmImage: ''
+  scriptFileName: ''
+  scriptArgs: 'all'
+  timeoutInMinutes: 120
+  outputDirectory: 'bin/nuget'
+
+jobs:
+  - job: ${{ parameters.name }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    pool:
+      vmImage: ${{ parameters.vmImage }}
+    steps:
+      - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+        clean: false  # whether to fetch clean each time
+        submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+        persistCredentials: true
+      # Linux or macOS
+      - task: Bash@3 
+        displayName: Linux / OSX Build
+        inputs:
+          filePath: ${{ parameters.scriptFileName }}
+          arguments: ${{ parameters.scriptArgs }}
+        continueOnError: true
+        condition: in( variables['Agent.OS'], 'Linux', 'Darwin' )
+      # Windows
+      - task: BatchScript@1
+        displayName: Windows Build
+        inputs:
+          filename: ${{ parameters.scriptFileName }}
+          arguments: ${{ parameters.scriptArgs }}
+        continueOnError: true
+        condition: eq( variables['Agent.OS'], 'Windows_NT' )
+      - task: PublishTestResults@2
+        inputs:
+          testRunner: VSTest
+          testResultsFiles: '**/*.trx' #TestResults folder usually
+          testRunTitle: ${{ parameters.name }}
+          mergeTestResults: true
+      - task: CopyFiles@2
+        displayName: 'Copy Build Output'
+        inputs:
+          sourceFolder: ${{ parameters.outputDirectory }}
+          contents: '**\*'
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          continueOnError: boolean  # 'true' if future steps should run even if this step fails; defaults to 'false'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: ${{ parameters.name }}
+      - script: 'echo 1>&2'
+        failOnStderr: true
+        displayName: 'If above is partially succeeded, then fail'
+        condition: eq(variables['Agent.JobStatus'], 'SucceededWithIssues')

--- a/build-system/linux-pr-validation.yaml
+++ b/build-system/linux-pr-validation.yaml
@@ -1,0 +1,22 @@
+# Pull request validation for Linux against the `dev` and `master` branches
+# See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
+trigger:
+  branches:
+    include:
+      - dev
+      - master
+
+name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
+
+pr:
+  autoCancel: true # indicates whether additional pushes to a PR should cancel in-progress runs for the same PR. Defaults to true
+  branches:
+    include: [ dev, master ] # branch names which will trigger a build
+
+jobs:
+- template: azure-pipeline.template.yaml
+  parameters:
+    name: Ubuntu
+    vmImage: 'ubuntu-16.04'
+    scriptFileName: ./build.sh
+    scriptArgs: all

--- a/build-system/nightly-builds.yaml
+++ b/build-system/nightly-builds.yaml
@@ -1,0 +1,26 @@
+# Release task for PbLib projects
+# See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
+
+pool:
+  vmImage: vs2017-win2016
+  demands: Cmd
+
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - dev
+
+variables:
+  - group: nugetKeys #create this group with SECRET variables `nugetKey`
+
+steps:
+- task: BatchScript@1
+  displayName: 'FAKE Build'
+  inputs:
+    filename: build.cmd
+    arguments: 'Nuget nugetprerelease=dev nugetpublishurl=$(nightlyUrl) nugetkey=$(nightlyKey)'

--- a/build-system/windows-pr-validation.yaml
+++ b/build-system/windows-pr-validation.yaml
@@ -1,0 +1,22 @@
+# Pull request validation for Windows against the `dev` and `master` branches
+# See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
+trigger:
+  branches:
+    include:
+      - dev
+      - master
+
+pr:
+  autoCancel: true # indicates whether additional pushes to a PR should cancel in-progress runs for the same PR. Defaults to true
+  branches:
+    include: [ dev, master ] # branch names which will trigger a build
+
+name: $(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
+
+jobs:
+- template: azure-pipeline.template.yaml
+  parameters:
+    name: Windows
+    vmImage: 'vs2017-win2016'
+    scriptFileName: build.cmd
+    scriptArgs: all

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -1,0 +1,38 @@
+# Release task for PbLib projects
+# See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
+
+pool:
+  vmImage: vs2017-win2016
+  demands: Cmd
+
+trigger:
+  branches:
+    include:
+      - refs/tags/*
+pr: none
+
+variables:
+  - group: nugetKeys #create this group with SECRET variables `nugetKey`
+  - name: githubConnectionName
+    value: AkkaDotNet_Releases #replace this
+  - name: projectName
+    value: Hyperion #replace this
+  - name: githubRepositoryName
+    value: akkadotnet/Hyperion #replace this
+
+steps:
+- task: BatchScript@1
+  displayName: 'FAKE Build'
+  inputs:
+    filename: build.cmd
+    arguments: 'All SignClientUser=$(signingUsername) SignClientSecret=$(signingPassword) nugetpublishurl=https://www.nuget.org/api/v2/package nugetkey=$(nugetKey)'
+
+- task: GitHubRelease@0
+  displayName: 'GitHub release (create)'
+  inputs:
+    gitHubConnection: $(githubConnectionName)
+    repositoryName: $(githubRepositoryName)
+    title: '$(projectName) v$(Build.SourceBranchName)'
+    releaseNotesFile: 'RELEASE_NOTES.md'
+    assets: |
+     bin\nuget\*.nupkg

--- a/build.fsx
+++ b/build.fsx
@@ -8,15 +8,22 @@ open System.Text
 open Fake
 open Fake.DotNetCli
 open Fake.DocFxHelper
-open Fake.FileHelper
 
 // Information about the project for Nuget and Assembly info files
+let product = "Hyperion"
 let configuration = "Release"
+
+// Metadata used when signing packages and DLLs
+let signingName = "Hyperion"
+let signingDescription = "A high performance polymorphic serializer for the .NET framework"
+let signingUrl = ""
+
 
 // Read release notes and version
 let solutionFile = FindFirstMatchingFile "*.sln" __SOURCE_DIRECTORY__  // dynamically look up the solution
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
-let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString()) 
+let hasTeamCity = (not (buildNumber = "0")) // check if we have the TeamCity environment variable for build # set
+let preReleaseVersionSuffix = "beta" + (if (not (buildNumber = "0")) then (buildNumber) else DateTime.UtcNow.Ticks.ToString())
 let versionSuffix = 
     match (getBuildParam "nugetprerelease") with
     | "dev" -> preReleaseVersionSuffix
@@ -33,19 +40,14 @@ let outputTests = __SOURCE_DIRECTORY__ @@ "TestResults"
 let outputPerfTests = __SOURCE_DIRECTORY__ @@ "PerfResults"
 let outputNuGet = output @@ "nuget"
 
-// Copied from original NugetCreate target
-let nugetDir = output @@ "nuget"
-let workingDir = output @@ "build"
-let nugetExe = FullName @"./tools/nuget.exe"
-
 Target "Clean" (fun _ ->
+    ActivateFinalTarget "KillCreatedProcesses"
+
     CleanDir output
     CleanDir outputTests
     CleanDir outputPerfTests
     CleanDir outputNuGet
     CleanDir "docs/_site"
-    CleanDirs !! "./**/bin"
-    CleanDirs !! "./**/obj"
 )
 
 Target "AssemblyInfo" (fun _ ->
@@ -53,29 +55,14 @@ Target "AssemblyInfo" (fun _ ->
     XmlPokeInnerText "./src/common.props" "//Project/PropertyGroup/PackageReleaseNotes" (releaseNotes.Notes |> String.concat "\n")
 )
 
-Target "RestorePackages" (fun _ ->
-    DotNetCli.Restore
+Target "Build" (fun _ ->          
+    DotNetCli.Build
         (fun p -> 
             { p with
                 Project = solutionFile
-                NoCache = false})
+                Configuration = configuration }) // "Rebuild"  
 )
 
-Target "Build" (fun _ ->   
-    let additionalArgs = if versionSuffix.Length > 0 then [sprintf "/p:VersionSuffix=%s" versionSuffix;"--no-incremental"] else ["--no-incremental"]  
-       
-    let runSingleProject project =
-        DotNetCli.Build
-            (fun p -> 
-                { p with
-                    Project = project
-                    Configuration = configuration 
-                    AdditionalArgs = additionalArgs}) // "Rebuild"  
-
-    let assemblies = !! "./src/**/*.*sproj" 
-     
-    assemblies |> Seq.iter (runSingleProject)
-)
 
 //--------------------------------------------------------------------------------
 // Tests targets 
@@ -105,12 +92,17 @@ Target "RunTests" (fun _ ->
         | _ -> !! "./src/**/*.Tests.csproj" // if you need to filter specs for Linux vs. Windows, do it here
 
     let runSingleProject project =
+        let arguments =
+            match (hasTeamCity) with
+            | true -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none -teamcity" (outputTests))
+            | false -> (sprintf "test -c Release --no-build --logger:trx --logger:\"console;verbosity=normal\" --results-directory %s -- -parallel none" (outputTests))
+
         let result = ExecProcess(fun info ->
             info.FileName <- "dotnet"
             info.WorkingDirectory <- (Directory.GetParent project).FullName
-            info.Arguments <- (sprintf "xunit -c Release -nobuild -parallel none -teamcity -xml %s_xunit.xml" (outputTests @@ fileNameWithoutExt project))) (TimeSpan.FromMinutes 30.)
+            info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0) 
         
-        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.DontFailBuild result
+        ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result  
 
     projects |> Seq.iter (log)
     projects |> Seq.iter (runSingleProject)
@@ -120,7 +112,7 @@ Target "NBench" <| fun _ ->
     let nbenchTestPath = findToolInSubPath "NBench.Runner.exe" (toolsDir @@ "NBench.Runner*")
     printfn "Using NBench.Runner: %s" nbenchTestPath
 
-    let nbenchTestAssemblies = !! "./src/**/*Tests.Performance.csproj" 
+    let nbenchTestAssemblies = !! "./src/**/bin/**/*Tests.Performance.dll" // doesn't support .NET Core at the moment
 
     let runNBench assembly =
         let includes = getBuildParam "include"
@@ -146,10 +138,59 @@ Target "NBench" <| fun _ ->
             info.FileName <- nbenchTestPath
             info.WorkingDirectory <- (Path.GetDirectoryName (FullName nbenchTestPath))
             info.Arguments <- args) (System.TimeSpan.FromMinutes 45.0) (* Reasonably long-running task. *)
+        
         if result <> 0 then failwithf "NBench.Runner failed. %s %s" nbenchTestPath args
     
     nbenchTestAssemblies |> Seq.iter runNBench
 
+
+//--------------------------------------------------------------------------------
+// Code signing targets
+//--------------------------------------------------------------------------------
+Target "SignPackages" (fun _ ->
+    let canSign = hasBuildParam "SignClientSecret" && hasBuildParam "SignClientUser"
+    if(false) then
+        log "Signing information is available."
+        
+        let assemblies = !! (outputNuGet @@ "*.nupkg")
+
+        let signPath =
+            let globalTool = tryFindFileOnPath "SignClient.exe"
+            match globalTool with
+                | Some t -> t
+                | None -> if isWindows then findToolInSubPath "SignClient.exe" "tools/signclient"
+                          elif isMacOS then findToolInSubPath "SignClient" "tools/signclient"
+                          else findToolInSubPath "SignClient" "tools/signclient"
+
+        let signAssembly assembly =
+            let args = StringBuilder()
+                    |> append "sign"
+                    |> append "--config"
+                    |> append (__SOURCE_DIRECTORY__ @@ "appsettings.json") 
+                    |> append "-i"
+                    |> append assembly
+                    |> append "-r"
+                    |> append (getBuildParam "SignClientUser")
+                    |> append "-s"
+                    |> append (getBuildParam "SignClientSecret")
+                    |> append "-n"
+                    |> append signingName
+                    |> append "-d"
+                    |> append signingDescription
+                    |> append "-u"
+                    |> append signingUrl
+                    |> toText
+
+            let result = ExecProcess(fun info -> 
+                info.FileName <- signPath
+                info.WorkingDirectory <- __SOURCE_DIRECTORY__
+                info.Arguments <- args) (System.TimeSpan.FromMinutes 5.0) (* Reasonably long-running task. *)
+            if result <> 0 then failwithf "SignClient failed.%s" args
+
+        assemblies |> Seq.iter (signAssembly)
+    else
+        log "SignClientSecret not available. Skipping signing"
+)
 
 //--------------------------------------------------------------------------------
 // Nuget targets 
@@ -162,7 +203,6 @@ Target "CreateNuget" (fun _ ->
     let projects = !! "src/**/*.csproj" 
                    -- "src/**/*Tests.csproj" // Don't publish unit tests
                    -- "src/**/*Tests*.csproj"
-                   -- "src/**/*.Demo.csproj" // Don't publish demo apps
 
     let runSingleProject project =
         DotNetCli.Pack
@@ -170,7 +210,7 @@ Target "CreateNuget" (fun _ ->
                 { p with
                     Project = project
                     Configuration = configuration
-                    AdditionalArgs = ["--include-symbols"]
+                    AdditionalArgs = ["--include-symbols --no-build"]
                     VersionSuffix = overrideVersionSuffix project
                     OutputPath = outputNuGet })
 
@@ -221,6 +261,19 @@ Target "DocFx" (fun _ ->
 )
 
 //--------------------------------------------------------------------------------
+// Cleanup
+//--------------------------------------------------------------------------------
+
+FinalTarget "KillCreatedProcesses" (fun _ ->
+    log "Shutting down dotnet build-server"
+    let result = ExecProcess(fun info -> 
+            info.FileName <- "dotnet"
+            info.WorkingDirectory <- __SOURCE_DIRECTORY__
+            info.Arguments <- "build-server shutdown") (System.TimeSpan.FromMinutes 2.0)
+    if result <> 0 then failwithf "dotnet build-server shutdown failed"
+)
+
+//--------------------------------------------------------------------------------
 // Help 
 //--------------------------------------------------------------------------------
 
@@ -230,11 +283,12 @@ Target "Help" <| fun _ ->
       "./build.ps1 [target]"
       ""
       " Targets for building:"
-      " * Build      Builds"
-      " * Nuget      Create and optionally publish nugets packages"
-      " * RunTests   Runs tests"
-      " * All        Builds, run tests, creates and optionally publish nuget packages"
-      " * DocFx      Creates a DocFx-based website for this solution"
+      " * Build         Builds"
+      " * Nuget         Create and optionally publish nugets packages"
+      " * SignPackages  Signs all NuGet packages, provided that the following arguments are passed into the script: SignClientSecret={secret} and SignClientUser={username}"
+      " * RunTests      Runs tests"
+      " * All           Builds, run tests, creates and optionally publish nuget packages"
+      " * DocFx         Creates a DocFx-based website for this solution"
       ""
       " Other Targets"
       " * Help       Display this help" 
@@ -249,21 +303,22 @@ Target "All" DoNothing
 Target "Nuget" DoNothing
 
 // build dependencies
-"Clean" ==> "RestorePackages" ==> "AssemblyInfo" ==> "Build" ==> "BuildRelease"
+"Clean" ==> "AssemblyInfo" ==> "Build" ==> "BuildRelease"
 
 // tests dependencies
+"Build" ==> "RunTests"
 
 // nuget dependencies
-"Clean" ==> "RestorePackages" ==> "Build" ==> "CreateNuget"
-"CreateNuget" ==> "PublishNuget" ==> "Nuget"
+"Clean" ==> "Build" ==> "CreateNuget"
+"CreateNuget" ==> "SignPackages" ==> "PublishNuget" ==> "Nuget"
 
 // docs
-"BuildRelease" ==> "Docfx"
+"Clean" ==> "BuildRelease" ==> "Docfx"
 
 // all
 "BuildRelease" ==> "All"
 "RunTests" ==> "All"
-//"NBench" ==> "All"
+"NBench" ==> "All"
 "Nuget" ==> "All"
 
 RunTargetOrDefault "Help"

--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ Param(
 )
 
 $FakeVersion = "4.61.2"
-$NBenchVersion = "1.0.1"
+$NBenchVersion = "1.2.2"
 $DotNetChannel = "LTS";
 $DotNetVersion = "2.0.0";
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/v$DotNetVersion/scripts/obtain/dotnet-install.ps1";

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,9 @@ FAKE_VERSION=4.61.2
 FAKE_EXE=$TOOLS_DIR/FAKE/tools/FAKE.exe
 DOTNET_VERSION=2.0.3
 DOTNET_INSTALLER_URL=https://raw.githubusercontent.com/dotnet/cli/v$DOTNET_VERSION/scripts/obtain/dotnet-install.sh
+DOTNET_CHANNEL=LTS;
+DOCFX_VERSION=2.40.5
+DOCFX_EXE=$TOOLS_DIR/docfx.console/tools/docfx.exe
 
 # Define default arguments.
 TARGET="Default"
@@ -47,12 +50,13 @@ if [ ! -d "$SCRIPT_DIR/.dotnet" ]; then
   mkdir "$SCRIPT_DIR/.dotnet"
 fi
 curl -Lsfo "$SCRIPT_DIR/.dotnet/dotnet-install.sh" $DOTNET_INSTALLER_URL
-bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --install-dir .dotnet --no-path
+bash "$SCRIPT_DIR/.dotnet/dotnet-install.sh" --version $DOTNET_VERSION --channel $DOTNET_CHANNEL --install-dir .dotnet --no-path
 export PATH="$SCRIPT_DIR/.dotnet":$PATH
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 chmod -R 0755 ".dotnet"
 "$SCRIPT_DIR/.dotnet/dotnet" --info
+
 
 ###########################################################################
 # INSTALL NUGET
@@ -83,6 +87,23 @@ fi
 # Make sure that Fake has been installed.
 if [ ! -f "$FAKE_EXE" ]; then
     echo "Could not find Fake.exe at '$FAKE_EXE'."
+    exit 1
+fi
+
+###########################################################################
+# INSTALL DOCFX
+###########################################################################
+if [ ! -f "$DOCFX_EXE" ]; then
+    mono "$NUGET_EXE" install docfx.console -ExcludeVersion -Version $DOCFX_VERSION -OutputDirectory "$TOOLS_DIR"
+    if [ $? -ne 0 ]; then
+        echo "An error occured while installing DocFx."
+        exit 1
+    fi
+fi
+
+# Make sure that DocFx has been installed.
+if [ ! -f "$DOCFX_EXE" ]; then
+    echo "Could not find docfx.exe at '$DOCFX_EXE'."
     exit 1
 fi
 

--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyTitle>Hyperion</AssemblyTitle>
     <Description>Hyperion, fast binary POCO serializer</Description>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net452</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>serialization;poco</PackageTags>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
@@ -15,12 +15,12 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);SERIALIZATION;UNSAFE;NET45</DefineConstants>
   </PropertyGroup>
 

--- a/src/common.props
+++ b/src/common.props
@@ -12,5 +12,6 @@
   <PropertyGroup>
     <XunitVersion>2.3.0</XunitVersion>
     <TestSdkVersion>15.3.0</TestSdkVersion>
+    <NBenchVersion>1.2.2</NBenchVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Bumped hyperion core to net452
- Updated build scripts to latest version. This included nbench targets although its not used in the solution. Did this so we end up with the same scripts all around. Makes it easier to maintain since there is no need for different build descriptions for each repo.
- Note that signing targets are also in there, but they are disabled in the target itself