### PR TITLE
moved Hyperion back to .NET 4.5

### DIFF
--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyTitle>Hyperion</AssemblyTitle>
     <Description>Hyperion, fast binary POCO serializer</Description>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>serialization;poco</PackageTags>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
@@ -33,7 +33,7 @@
     <DefineConstants>$(DefineConstants);NETSTANDARD20</DefineConstants>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>$(DefineConstants);SERIALIZATION;UNSAFE;NET45</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
need to do this in order to release a patch that will allow us to run Hyperion in .NET Core 3.0 on Akka.NET v1.3.*