### PR TITLE
added v0.9.11 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-### 0.9.10 October 15 2019 ####
+### 0.9.11 November 13 2019 ####
 
-Hyperion now [supports cross-framework communication between .NET Core and .NET Framework](https://github.com/akkadotnet/Hyperion/pull/116).
+[Hyperion now targets .NET 4.5 again so it can be included inside Akka.NET v1.3.* releases](https://github.com/akkadotnet/Hyperion/pull/141).

--- a/src/common.props
+++ b/src/common.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <Copyright>Copyright © 2016-2017 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>0.9.10</VersionPrefix>
-    <PackageReleaseNotes>Hyperion now [supports cross-framework communication between .NET Core and .NET Framework](https://github.com/akkadotnet/Hyperion/pull/116).</PackageReleaseNotes>
+    <VersionPrefix>0.9.11</VersionPrefix>
+    <PackageReleaseNotes>[Hyperion now targets .NET 4.5 again so it can be included inside Akka.NET v1.3.* releases](https://github.com/akkadotnet/Hyperion/pull/141).</PackageReleaseNotes>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Hyperion</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/Hyperion/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
### 0.9.11 November 13 2019 ####

[Hyperion now targets .NET 4.5 again so it can be included inside Akka.NET v1.3.* releases](https://github.com/akkadotnet/Hyperion/pull/141).