### PR TITLE
Fix version tolerance when bad assembly version specified in type manifest

### DIFF
--- a/src/Hyperion.Tests/Bugs.cs
+++ b/src/Hyperion.Tests/Bugs.cs
@@ -114,7 +114,7 @@ namespace Hyperion.Tests
             var fullName = type.AssemblyQualifiedName;
             var fullNameStream = GetStreamForManifest(fullName);
             // Set bad assembly version to make deserialization fail
-            var fullNameWithUnknownVersion = fullName.Remove(fullName.IndexOf(", Version=")) + ", Version=bad, Culture=neutral, PublicKeyToken=null";
+            var fullNameWithUnknownVersion = fullName.Remove(fullName.IndexOf(", Version=")) + ", Version=, Culture=neutral, PublicKeyToken=null";
             var fullNameWithUnknownVersionStream = GetStreamForManifest(fullNameWithUnknownVersion);
 
             this.Invoking(_ => TypeEx.GetTypeFromManifestFull(shortNameStream, serializer.GetDeserializerSession()))
@@ -139,7 +139,19 @@ namespace Hyperion.Tests
                 throw new Exception($"CoreAssemblyName private static field does not exist in {nameof(TypeEx)} class anymore");
             
             version.Should().Be("System.Collections.Immutable.ImmutableDictionary`2" +
-                                $"[[System.String, mscorlib{coreAssemblyName}],[System.Int32, mscorlib{coreAssemblyName}]], System.Collections.Immutable");
+                                $"[[System.String, mscorlib{coreAssemblyName}],[System.Int32, mscorlib{coreAssemblyName}]], System.Collections.Immutable, PublicKeyToken=b03f5f7f11d50a3a");
+        }
+        
+        [Fact]
+        public void TypeEx_ToQualifiedAssemblyName_should_strip_version_correctly_for_multiple_versions_specified()
+        {
+            var version = TypeEx.ToQualifiedAssemblyName(
+                "System.Collections.Immutable.ImmutableList`1[[Foo.Bar, Foo, Version=2019.12.10.1]], " +
+                "System.Collections.Immutable, Version=1.2.2.0, PublicKeyToken=b03f5f7f11d50a3a",
+                ignoreAssemblyVersion: true);
+
+            version.Should().Be("System.Collections.Immutable.ImmutableList`1[[Foo.Bar, Foo]], " +
+                                "System.Collections.Immutable, PublicKeyToken=b03f5f7f11d50a3a");
         }
 
         [Fact]

--- a/src/Hyperion.Tests/Bugs.cs
+++ b/src/Hyperion.Tests/Bugs.cs
@@ -127,6 +127,20 @@ namespace Hyperion.Tests
         }
 
         [Fact]
+        public void TypeEx_ToQualifiedAssemblyName_should_strip_version_correctly_for_mscorlib_substitution()
+        {
+            var version = TypeEx.ToQualifiedAssemblyName(
+                "System.Collections.Immutable.ImmutableDictionary`2[[System.String, mscorlib,%core%],[System.Int32, mscorlib,%core%]]," +
+                " System.Collections.Immutable, Version=1.2.1.0, PublicKeyToken=b03f5f7f11d50a3a",
+                ignoreAssemblyVersion: true);
+            
+            version.Should().Be("System.Collections.Immutable.ImmutableDictionary`2" +
+                                "[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, " +
+                                "PublicKeyToken=7cec85d7bea7798e],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, " +
+                                "PublicKeyToken=7cec85d7bea7798e]], System.Collections.Immutable");
+        }
+
+        [Fact]
         public void CanSerialieCustomType_bug()
         {
             var stream = new MemoryStream();

--- a/src/Hyperion.Tests/Bugs.cs
+++ b/src/Hyperion.Tests/Bugs.cs
@@ -133,11 +133,13 @@ namespace Hyperion.Tests
                 "System.Collections.Immutable.ImmutableDictionary`2[[System.String, mscorlib,%core%],[System.Int32, mscorlib,%core%]]," +
                 " System.Collections.Immutable, Version=1.2.1.0, PublicKeyToken=b03f5f7f11d50a3a",
                 ignoreAssemblyVersion: true);
+
+            var coreAssemblyName = typeof(TypeEx).GetField("CoreAssemblyName", BindingFlags.Static | BindingFlags.NonPublic)?.GetValue(null);
+            if (coreAssemblyName == null)
+                throw new Exception($"CoreAssemblyName private static field does not exist in {nameof(TypeEx)} class anymore");
             
             version.Should().Be("System.Collections.Immutable.ImmutableDictionary`2" +
-                                "[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, " +
-                                "PublicKeyToken=7cec85d7bea7798e],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, " +
-                                "PublicKeyToken=7cec85d7bea7798e]], System.Collections.Immutable");
+                                $"[[System.String, mscorlib{coreAssemblyName}],[System.Int32, mscorlib{coreAssemblyName}]], System.Collections.Immutable");
         }
 
         [Fact]

--- a/src/Hyperion.Tests/Bugs.cs
+++ b/src/Hyperion.Tests/Bugs.cs
@@ -114,7 +114,7 @@ namespace Hyperion.Tests
             var fullName = type.AssemblyQualifiedName;
             var fullNameStream = GetStreamForManifest(fullName);
             // Set bad assembly version to make deserialization fail
-            var fullNameWithUnknownVersion = fullName.Remove(fullName.IndexOf(", Version=")) + ", Version=, Culture=neutral, PublicKeyToken=null";
+            var fullNameWithUnknownVersion = fullName.Remove(fullName.IndexOf(", Version=")) + ", Version=999999, Culture=neutral, PublicKeyToken=null";
             var fullNameWithUnknownVersionStream = GetStreamForManifest(fullNameWithUnknownVersion);
 
             this.Invoking(_ => TypeEx.GetTypeFromManifestFull(shortNameStream, serializer.GetDeserializerSession()))
@@ -139,7 +139,7 @@ namespace Hyperion.Tests
                 throw new Exception($"CoreAssemblyName private static field does not exist in {nameof(TypeEx)} class anymore");
             
             version.Should().Be("System.Collections.Immutable.ImmutableDictionary`2" +
-                                $"[[System.String, mscorlib{coreAssemblyName}],[System.Int32, mscorlib{coreAssemblyName}]], System.Collections.Immutable, PublicKeyToken=b03f5f7f11d50a3a");
+                                $"[[System.String, mscorlib{coreAssemblyName}],[System.Int32, mscorlib{coreAssemblyName}]], System.Collections.Immutable");
         }
         
         [Fact]
@@ -150,8 +150,7 @@ namespace Hyperion.Tests
                 "System.Collections.Immutable, Version=1.2.2.0, PublicKeyToken=b03f5f7f11d50a3a",
                 ignoreAssemblyVersion: true);
 
-            version.Should().Be("System.Collections.Immutable.ImmutableList`1[[Foo.Bar, Foo]], " +
-                                "System.Collections.Immutable, PublicKeyToken=b03f5f7f11d50a3a");
+            version.Should().Be("System.Collections.Immutable.ImmutableList`1[[Foo.Bar, Foo]], System.Collections.Immutable");
         }
 
         [Fact]

--- a/src/Hyperion.Tests/Hyperion.Tests.csproj
+++ b/src/Hyperion.Tests/Hyperion.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Hyperion/Extensions/TypeEx.cs
+++ b/src/Hyperion/Extensions/TypeEx.cs
@@ -231,6 +231,12 @@ namespace Hyperion.Extensions
         public static string ToQualifiedAssemblyName(string shortName)
         {
             var res = shortName.Replace(",%core%", CoreAssemblyName);
+            
+            // Strip out assembly version, if specified
+            var versionSubstrIndex = res.IndexOf(", Version=", StringComparison.Ordinal);
+            if (versionSubstrIndex >= 0)
+                res = res.Remove(versionSubstrIndex);
+            
             return res;
         }
 

--- a/src/Hyperion/Extensions/TypeEx.cs
+++ b/src/Hyperion/Extensions/TypeEx.cs
@@ -248,8 +248,7 @@ namespace Hyperion.Extensions
             // Strip out assembly version, if specified
             if (ignoreAssemblyVersion)
             {
-                var versionRegex = new Regex(@",[\s]*Version=[0-9\.]*");
-                shortName = versionRegex.Replace(shortName, string.Empty);
+                shortName = cleanAssemblyVersionRegex.Replace(shortName, string.Empty);
             }
             
             var res = shortName.Replace(",%core%", CoreAssemblyName);

--- a/src/Hyperion/Extensions/TypeEx.cs
+++ b/src/Hyperion/Extensions/TypeEx.cs
@@ -248,9 +248,8 @@ namespace Hyperion.Extensions
             // Strip out assembly version, if specified
             if (ignoreAssemblyVersion)
             {
-                var versionSubstrIndex = shortName.IndexOf(", Version=", StringComparison.Ordinal);
-                if (versionSubstrIndex >= 0)
-                    shortName = shortName.Remove(versionSubstrIndex);
+                var versionRegex = new Regex(@",[\s]*Version=[0-9\.]*");
+                shortName = versionRegex.Replace(shortName, string.Empty);
             }
             
             var res = shortName.Replace(",%core%", CoreAssemblyName);

--- a/src/Hyperion/Extensions/TypeEx.cs
+++ b/src/Hyperion/Extensions/TypeEx.cs
@@ -245,15 +245,15 @@ namespace Hyperion.Extensions
 
         public static string ToQualifiedAssemblyName(string shortName, bool ignoreAssemblyVersion)
         {
-            var res = shortName.Replace(",%core%", CoreAssemblyName);
-            
             // Strip out assembly version, if specified
             if (ignoreAssemblyVersion)
             {
-                var versionSubstrIndex = res.IndexOf(", Version=", StringComparison.Ordinal);
+                var versionSubstrIndex = shortName.IndexOf(", Version=", StringComparison.Ordinal);
                 if (versionSubstrIndex >= 0)
-                    res = res.Remove(versionSubstrIndex);
+                    shortName = shortName.Remove(versionSubstrIndex);
             }
+            
+            var res = shortName.Replace(",%core%", CoreAssemblyName);
             
             return res;
         }

--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -24,6 +24,11 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Hyperion.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD16</DefineConstants>

--- a/src/Hyperion/ValueSerializers/TypeSerializer.cs
+++ b/src/Hyperion/ValueSerializers/TypeSerializer.cs
@@ -66,8 +66,7 @@ namespace Hyperion.ValueSerializers
             if (shortname == null)
                 return null;
 
-            var name = TypeEx.ToQualifiedAssemblyName(shortname);
-            var type = Type.GetType(name,true);
+            var type = TypeEx.LoadTypeByName(shortname);
 
             //add the deserialized type to lookup
             if (session.Serializer.Options.PreserveObjectReferences)


### PR DESCRIPTION
Close #144 

The basic idea is to ignore assembly version, if it is specified in incoming message type's manifest.