### PR TITLE
rewrote CrossFrameworkSerializationTests as xUnit theory

### DIFF
--- a/src/Hyperion.Tests/CrossFrameworkSerializationTests.cs
+++ b/src/Hyperion.Tests/CrossFrameworkSerializationTests.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Hyperion.Tests.Generator;
 using Xunit;
 
@@ -15,22 +18,22 @@ namespace Hyperion.Tests
             _originalObject = CrossFrameworkInitializer.Init();
         }
 
-        [Fact]
-        public void CanSerializeCrossFramework()
+        public static IEnumerable<object[]> SerializationFiles()
         {
             const string defaultOutputPath = CrossFrameworkInitializer.DefaultOutputPath;
             var testFiles = Directory.GetFiles(defaultOutputPath, "*.tf");
+            return testFiles.Select(x => new object[] { x });
+        }
 
-            Assert.NotEmpty(testFiles);
-
-            foreach (string testFile in testFiles)
+        [Theory]
+        [MemberData(nameof(SerializationFiles))]
+        public void CanSerializeCrossFramework(string fileName)
+        {
+            using (var fileStream = new FileStream(fileName, FileMode.Open))
             {
-                using (var fileStream = new FileStream(testFile, FileMode.Open))
-                {
-                    var crossFrameworkClass = _serializer.Deserialize<CrossFrameworkClass>(fileStream);
+                var crossFrameworkClass = _serializer.Deserialize<CrossFrameworkClass>(fileStream);
 
-                    Assert.Equal(_originalObject, crossFrameworkClass);
-                }
+                Assert.Equal(_originalObject, crossFrameworkClass);
             }
         }
     }


### PR DESCRIPTION
Making it easier to see which combination of platforms resulted in a failure