### PR TITLE
Update IDictionary<T, V> serializer to not use IDictionary assumption

### DIFF
--- a/src/Hyperion.Tests/GenericDictionarySerializerTests.cs
+++ b/src/Hyperion.Tests/GenericDictionarySerializerTests.cs
@@ -30,10 +30,9 @@ namespace Hyperion.Tests
         /// <summary>
         /// Just a custom class wrapper for another <see cref="IDictionary{TKey,TValue}"/>
         /// </summary>
-        class CustomDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary
+        class CustomDictionary<TKey, TValue> : IDictionary<TKey, TValue>
         {
             private readonly IDictionary<TKey, TValue> _dictGeneric;
-            private readonly IDictionary _dict;
 
             /// <summary>
             /// For serialization
@@ -45,29 +44,7 @@ namespace Hyperion.Tests
             public CustomDictionary(Dictionary<TKey, TValue> dict)
             {
                 _dictGeneric = dict;
-                _dict = dict;
             }
-
-            /// <inheritdoc />
-            public bool Contains(object key)
-            {
-                return _dict.Contains(key);
-            }
-
-            /// <inheritdoc />
-            IDictionaryEnumerator IDictionary.GetEnumerator()
-            {
-                return _dict.GetEnumerator();
-            }
-
-            /// <inheritdoc />
-            public void Remove(object key)
-            {
-                _dict.Remove(key);
-            }
-
-            /// <inheritdoc />
-            public bool IsFixedSize => _dict.IsFixedSize;
 
             /// <inheritdoc />
             public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
@@ -85,12 +62,6 @@ namespace Hyperion.Tests
             public void Add(KeyValuePair<TKey, TValue> item)
             {
                 _dictGeneric.Add(item);
-            }
-
-            /// <inheritdoc />
-            public void Add(object key, object? value)
-            {
-                _dict.Add(key, value);
             }
 
             /// <inheritdoc />
@@ -118,29 +89,10 @@ namespace Hyperion.Tests
             }
 
             /// <inheritdoc />
-            public void CopyTo(Array array, int index)
-            {
-                _dict.CopyTo(array, index);
-            }
-
-            /// <inheritdoc />
             public int Count => _dictGeneric.Count;
 
             /// <inheritdoc />
-            public bool IsSynchronized => _dict.IsSynchronized;
-
-            /// <inheritdoc />
-            public object SyncRoot => _dict.SyncRoot;
-
-            /// <inheritdoc />
             public bool IsReadOnly => _dictGeneric.IsReadOnly;
-
-            /// <inheritdoc />
-            public object? this[object key]
-            {
-                get => _dict[key];
-                set => _dict[key] = value;
-            }
 
             /// <inheritdoc />
             public void Add(TKey key, TValue value)
@@ -175,12 +127,6 @@ namespace Hyperion.Tests
 
             /// <inheritdoc />
             public ICollection<TKey> Keys => _dictGeneric.Keys;
-
-            /// <inheritdoc />
-            ICollection IDictionary.Values => _dict.Values;
-
-            /// <inheritdoc />
-            ICollection IDictionary.Keys => _dict.Keys;
 
             /// <inheritdoc />
             public ICollection<TValue> Values => _dictGeneric.Values;

--- a/src/Hyperion/SerializerFactories/DictionarySerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/DictionarySerializerFactory.cs
@@ -39,11 +39,12 @@ namespace Hyperion.SerializerFactories
             var preserveObjectReferences = serializer.Options.PreserveObjectReferences;
             var ser = new ObjectSerializer(type);
             typeMapping.TryAdd(type, ser);
-            var elementSerializer = serializer.GetSerializerByType(typeof (DictionaryEntry));
+            var dictionaryTypes = GetKeyValuePairType(type);
+            var elementSerializer = serializer.GetSerializerByType(dictionaryTypes.KeyValuePairType);
 
             ObjectReader reader = (stream, session) =>
             {
-                var instance = Activator.CreateInstance(type) as IDictionary;
+                var instance = Activator.CreateInstance(type); // IDictionary<TKey, TValue>
                 if (preserveObjectReferences)
                 {
                     session.TrackDeserializedObject(instance);
@@ -51,8 +52,16 @@ namespace Hyperion.SerializerFactories
                 var count = stream.ReadInt32(session);
                 for (var i = 0; i < count; i++)
                 {
-                    var entry = (DictionaryEntry) stream.ReadObject(session);
-                    instance.Add(entry.Key, entry.Value);
+                    var entry = stream.ReadObject(session); // KeyValuePair<TKey, TValue>
+                    
+                    // Get entry.Key and entry.Value
+                    var key = dictionaryTypes.KeyValuePairType.GetProperty(nameof(KeyValuePair<object, object>.Key)).GetValue(entry, null);
+                    var value = dictionaryTypes.KeyValuePairType.GetProperty(nameof(KeyValuePair<object, object>.Value)).GetValue(entry, null);
+                    
+                    // Same as: instance.Add(key, value)
+                    dictionaryTypes.DictionaryInterfaceType
+                        .GetMethod(nameof(IDictionary<object, object>.Add), new []{ dictionaryTypes.KeyType, dictionaryTypes.ValueType })
+                        .Invoke(instance, new [] { key, value });
                 }
                 
                 return instance;
@@ -64,19 +73,41 @@ namespace Hyperion.SerializerFactories
                 {
                     session.TrackSerializedObject(obj);
                 }
-                var dict = obj as IDictionary;
+                
+                var dict = obj as IEnumerable; // IDictionary<T, V> is IEnumerable<KeyValuePair<T, V>>
+                var count = dict.Cast<object>().Count();
                 // ReSharper disable once PossibleNullReferenceException
-                Int32Serializer.WriteValueImpl(stream, dict.Count, session);
+                Int32Serializer.WriteValueImpl(stream, count, session);
                 foreach (var item in dict)
                 {
-                    stream.WriteObject(item, typeof (DictionaryEntry), elementSerializer,
-                        serializer.Options.PreserveObjectReferences, session);
-                    // elementSerializer.WriteValue(stream,item,session);
+                    stream.WriteObject(item, dictionaryTypes.KeyValuePairType, elementSerializer, serializer.Options.PreserveObjectReferences, session);
                 }
             };
             ser.Initialize(reader, writer);
             
             return ser;
+        }
+
+        private GenericDictionaryTypes GetKeyValuePairType(Type dictImplementationType)
+        {
+            var dictInterface = dictImplementationType.GetInterfaces().First(i => i.GetGenericTypeDefinition() == typeof (IDictionary<,>));
+            var keyType = dictInterface.GetGenericArguments()[0];
+            var valueType = dictInterface.GetGenericArguments()[1];
+            return new GenericDictionaryTypes()
+            {
+                KeyType = keyType,
+                ValueType = valueType,
+                KeyValuePairType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType),
+                DictionaryInterfaceType = typeof(IDictionary<,>).MakeGenericType(keyType, valueType)
+            };
+        }
+
+        class GenericDictionaryTypes
+        {
+            public Type KeyType { get; set; }
+            public Type ValueType { get; set; }
+            public Type KeyValuePairType { get; set; }
+            public Type DictionaryInterfaceType { get; set; }
         }
     }
 }


### PR DESCRIPTION
Close #157

Some fun with reflection, and now it works without requiring `IDictionary` to be implemented.