### PR TITLE
Fix DictionarySerializerFactory to work with private or protected default constructor

### DIFF
--- a/src/Hyperion.Tests/GenericDictionarySerializerTests.cs
+++ b/src/Hyperion.Tests/GenericDictionarySerializerTests.cs
@@ -9,15 +9,41 @@ namespace Hyperion.Tests
     public class GenericDictionarySerializerTests : TestBase
     {
         [Fact]
-        public void CanSerializeDictionary()
+        public void CanSerializeDictionaryWithPublicDefaultConstructor()
         {
             var customDict = new CustomDictionary<string, int>(new Dictionary<string, int>()
             {
-                ["key"] = 1
+                ["key1"] = 1,
+                ["key2"] = 2,
+                ["key3"] = 2,
             });
             SerializeAndAssertEquivalent(customDict);
         }
-        
+
+        [Fact]
+        public void CanSerializeDictionaryWithPrivateDefaultConstructor()
+        {
+            var customDict = new PrivateCustomDictionary<string, int>(new Dictionary<string, int>()
+            {
+                ["key1"] = 1,
+                ["key2"] = 2,
+                ["key3"] = 2,
+            });
+            SerializeAndAssertEquivalent(customDict);
+        }
+
+        [Fact]
+        public void CanSerializeDictionaryWithProtectedDefaultConstructor()
+        {
+            var customDict = new ProtectedCustomDictionary<string, int>(new Dictionary<string, int>()
+            {
+                ["key1"] = 1,
+                ["key2"] = 2,
+                ["key3"] = 2,
+            });
+            SerializeAndAssertEquivalent(customDict);
+        }
+
         private void SerializeAndAssertEquivalent<T>(T expected)
         {
             Serialize(expected);
@@ -25,6 +51,24 @@ namespace Hyperion.Tests
             var res = Deserialize<T>();
             res.Should().BeEquivalentTo(expected);
             AssertMemoryStreamConsumed();
+        }
+
+        class PrivateCustomDictionary<TKey, TValue> : CustomDictionary<TKey, TValue>
+        {
+            private PrivateCustomDictionary() : base(new Dictionary<TKey, TValue>())
+            { }
+
+            public PrivateCustomDictionary(Dictionary<TKey, TValue> dict) : base(new Dictionary<TKey, TValue>())
+            { }
+        }
+
+        class ProtectedCustomDictionary<TKey, TValue> : CustomDictionary<TKey, TValue>
+        {
+            protected ProtectedCustomDictionary() : base(new Dictionary<TKey, TValue>())
+            { }
+
+            public ProtectedCustomDictionary(Dictionary<TKey, TValue> dict) : base(new Dictionary<TKey, TValue>())
+            { }
         }
 
         /// <summary>

--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -11,11 +11,13 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/Hyperion/SerializerFactories/DictionarySerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/DictionarySerializerFactory.cs
@@ -44,7 +44,14 @@ namespace Hyperion.SerializerFactories
 
             ObjectReader reader = (stream, session) =>
             {
-                var instance = Activator.CreateInstance(type); // IDictionary<TKey, TValue>
+                object instance;
+                try
+                {
+                    instance = Activator.CreateInstance(type, true); // IDictionary<TKey, TValue>
+                } catch(Exception) {
+                    instance = Activator.CreateInstance(type); // IDictionary<TKey, TValue>
+                }
+
                 if (preserveObjectReferences)
                 {
                     session.TrackDeserializedObject(instance);


### PR DESCRIPTION
`DictionarySerializerFactory.BuildSerializer()` does not play nicely with classes that uses private or protected default constructor. Modified the `Activator.CreateInstance()` call so that it tries to instantiate using a non-public constructor first, then tries to use the public constructor if the first attempt throws.