### PR TITLE
Fix Type.GetGenericTypeDefinition() interface error

### DIFF
--- a/src/Hyperion.Tests/GenericDictionarySerializerTests.cs
+++ b/src/Hyperion.Tests/GenericDictionarySerializerTests.cs
@@ -71,10 +71,15 @@ namespace Hyperion.Tests
             { }
         }
 
+        // Dictionary serializer fails to fetch the generic IDictionary interface if
+        // Type.GetInterfaces() returns a non-generic interface before the IDictionary interface
         /// <summary>
         /// Just a custom class wrapper for another <see cref="IDictionary{TKey,TValue}"/>
         /// </summary>
-        class CustomDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+        class CustomDictionary<TKey, TValue> :
+            IEnumerable, 
+            IDictionary<TKey, TValue>, 
+            IEquatable<CustomDictionary<TKey, TValue>>
         {
             private readonly IDictionary<TKey, TValue> _dictGeneric;
 
@@ -160,6 +165,11 @@ namespace Hyperion.Tests
             public bool TryGetValue(TKey key, out TValue value)
             {
                 return _dictGeneric.TryGetValue(key, out value);
+            }
+
+            public bool Equals(CustomDictionary<TKey, TValue> other)
+            {
+                return true;
             }
 
             /// <inheritdoc />

--- a/src/Hyperion/SerializerFactories/DictionarySerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/DictionarySerializerFactory.cs
@@ -97,7 +97,10 @@ namespace Hyperion.SerializerFactories
 
         private GenericDictionaryTypes GetKeyValuePairType(Type dictImplementationType)
         {
-            var dictInterface = dictImplementationType.GetInterfaces().First(i => i.GetGenericTypeDefinition() == typeof (IDictionary<,>));
+            var dictInterface = dictImplementationType
+                .GetInterfaces()
+                .Where(i => i.GetTypeInfo().IsGenericType)
+                .First(i => i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
             var keyType = dictInterface.GetGenericArguments()[0];
             var valueType = dictInterface.GetGenericArguments()[1];
             return new GenericDictionaryTypes()


### PR DESCRIPTION
`Type.GetGenericTypeDefinition()` in Dictionary serialization throws if the `Type.GetInterfaces()` of the class returns a non-generic interface before an `IDictionary` interface.