### PR TITLE
Order type fields by oridnal to keep the same order on multiple platforms

### DIFF
--- a/src/Hyperion.Tests/Bugs.cs
+++ b/src/Hyperion.Tests/Bugs.cs
@@ -489,5 +489,23 @@ namespace Hyperion.Tests
             Assert.DoesNotContain("System.Collections.Generic.Dictionary", text);
             Assert.Equal(msg, res);
         }
+
+        #region Issue 348
+
+        class FieldsToOrder
+        {
+            public string A2;
+            public string a1;
+        }
+
+        [Fact]
+        public void ShouldOrderFieldsByOrdinal()
+        {
+            string[] expected = { "A2", "a1" };
+            var actual = typeof(FieldsToOrder).GetFieldInfosForType().Select(x => x.Name).ToArray();
+            Assert.Equal(expected, actual);
+        }
+
+        #endregion
     }
 }

--- a/src/Hyperion/Extensions/ReflectionEx.cs
+++ b/src/Hyperion/Extensions/ReflectionEx.cs
@@ -48,7 +48,7 @@ namespace Hyperion.Extensions
                 fieldInfos.AddRange(tfields);
                 current = current.GetTypeInfo().BaseType;
             }
-            var fields = fieldInfos.OrderBy(f => f.Name).ToArray();
+            var fields = fieldInfos.OrderBy(f => f.Name, StringComparer.Ordinal).ToArray();
             return fields;
         }
     }


### PR DESCRIPTION
This PR fixes https://github.com/akkadotnet/akka.net/issues/5102.

The error is caused by differences in order of letters and special characters on different platforms.

This blog posts has more details of such differences and suggests using StringComparer.Ordinal.