### PR TITLE
updated benchmarks to run on modern .NET platforms

### DIFF
--- a/src/Hyperion.Benchmarks/Hyperion.Benchmarks.csproj
+++ b/src/Hyperion.Benchmarks/Hyperion.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable> <!-- prevents it from being published as NuGet package -->
   </PropertyGroup>
 

--- a/src/common.props
+++ b/src/common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2016-2017 Akka.NET Team</Copyright>
+    <Copyright>Copyright © 2016-2021 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
     <VersionPrefix>0.9.17</VersionPrefix>
     <PackageReleaseNotes>[Bump Microsoft.NET.Test.Sdk from 16.6.1 to 16.7.1](https://github.com/akkadotnet/Hyperion/pull/182)
@@ -19,7 +19,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <AkkaVersion>1.4.23</AkkaVersion>
-
     <FluentAssertionsVersion>6.0.0</FluentAssertionsVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <XunitRunnerVersion>2.4.3</XunitRunnerVersion>


### PR DESCRIPTION
Now targets: `net461`, `netcoreapp3.1`, and `net5.0`