### PR TITLE
Use IOException instead of FileLoadException to handle #269 where an …

### DIFF
--- a/src/Hyperion/Extensions/TypeEx.cs
+++ b/src/Hyperion/Extensions/TypeEx.cs
@@ -210,7 +210,7 @@ namespace Hyperion.Extensions
                         "Unsafe Type Deserialization Detected!", name);
                 return type;
             }
-            catch (FileLoadException)
+            catch (IOException)
             {
                 var typename = ToQualifiedAssemblyName(name, ignoreAssemblyVersion: true);
                 var type =  Type.GetType(typename, true);


### PR DESCRIPTION
Use IOException instead of FileLoadException to handle #269 where an FileNotFoundException is thrown