### PR TITLE
Fix SerializeStructBenchmark, Serializer not initialized

### DIFF
--- a/src/Hyperion.Benchmarks/Program.cs
+++ b/src/Hyperion.Benchmarks/Program.cs
@@ -8,8 +8,16 @@ namespace Hyperion.Benchmarks
     {
         static void Main(string[] args)
         {
-            var benchmark = BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly());
-            benchmark.RunAll();
+            var benchmark = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly);
+
+            if (args.Length == 0)
+            {
+                benchmark.RunAll();
+            }
+            else
+            {
+                benchmark.Run(args);
+            }
         }
     }
 }

--- a/src/Hyperion.Benchmarks/SerializeStructsBenchmark.cs
+++ b/src/Hyperion.Benchmarks/SerializeStructsBenchmark.cs
@@ -21,6 +21,7 @@ namespace Hyperion.Benchmarks
         
         protected override void Init()
         {
+            base.Init();
             standardValue = new StandardStruct(1, "John", "Doe", isLoggedIn: false);
             blittableValue = new BlittableStruct(59, 92);
             testEnum = TestEnum.HatesAll;


### PR DESCRIPTION
Hyperion.Benchmarks.SerializeStructsBenchmark did not initialize the `Serializer` field during `Init()` properly, it is null and NRE crashes the benchmark.