### PR TITLE
Improve EvilDeserializationException message

### DIFF
--- a/src/Hyperion/Internal/Annotations.cs
+++ b/src/Hyperion/Internal/Annotations.cs
@@ -23,7 +23,7 @@ namespace Hyperion.Internal
     public class EvilDeserializationException : SecurityException
     {
         public EvilDeserializationException(string message,
-            string typeString) : base(message)
+            string typeString) : base($"{message} [type: {typeString}]")
         {
             BadTypeString = typeString;
         }


### PR DESCRIPTION
Embed the type name in the exception message so that the offending type can be inspected in logs instead of having to inspect the exception instance itself