### PR TITLE
Convert byte array key to type cache from static to instance bound

### DIFF
--- a/src/Hyperion/Extensions/TypeEx.cs
+++ b/src/Hyperion/Extensions/TypeEx.cs
@@ -133,9 +133,6 @@ namespace Hyperion.Extensions
             return type.IsArray && type.GetArrayRank() == 1 && type.GetElementType().IsHyperionPrimitive();
         }
 
-        private static readonly ConcurrentDictionary<ByteArrayKey, Type> TypeNameLookup =
-            new ConcurrentDictionary<ByteArrayKey, Type>(ByteArrayKeyComparer.Instance);
-
         public static byte[] GetTypeManifest(IReadOnlyCollection<byte[]> fieldNames)
         {
             IEnumerable<byte> result = new[] { (byte)fieldNames.Count };
@@ -153,7 +150,7 @@ namespace Hyperion.Extensions
         {
             var bytes = stream.ReadLengthEncodedByteArray(session);
             var byteArr = ByteArrayKey.Create(bytes);
-            return TypeNameLookup.GetOrAdd(byteArr, b =>
+            return session.Serializer.TypeNameLookup.GetOrAdd(byteArr, b =>
             {
                 var shortName = StringEx.FromUtf8Bytes(b.Bytes, 0, b.Bytes.Length);
                 var overrides = session.Serializer.Options.CrossFrameworkPackageNameOverrides;

--- a/src/Hyperion/Serializer.cs
+++ b/src/Hyperion/Serializer.cs
@@ -34,6 +34,9 @@ namespace Hyperion
         
         public readonly SerializerOptions Options;
 
+        internal readonly ConcurrentDictionary<ByteArrayKey, Type> TypeNameLookup =
+            new ConcurrentDictionary<ByteArrayKey, Type>(ByteArrayKeyComparer.Instance);
+        
         public Serializer() : this(new SerializerOptions())
         {
         }


### PR DESCRIPTION
Part of  #303

Move static `TypeEx.TypeNameLookup` into a field of `Serializer` instead