### PR TITLE
Fix type cache cross pollination

### DIFF
--- a/src/Hyperion.Akka.Integration.Tests/IntegrationSpec.cs
+++ b/src/Hyperion.Akka.Integration.Tests/IntegrationSpec.cs
@@ -132,11 +132,19 @@ akka {
             
             try
             {
-                var serializer = system.Serialization.FindSerializerForType(typeof(DirectoryInfo));
+                var deserializer = system.Serialization.FindSerializerForType(typeof(DirectoryInfo));
                 var di = new DirectoryInfo(@"c:\");
+
+                byte[] serialized;
+                using (var stream = new MemoryStream())
+                {
+                    var serializer = new Serializer(SerializerOptions.Default.WithDisallowUnsafeType(false));
+                    serializer.Serialize(di, stream);
+                    stream.Position = 0;
+                    serialized = stream.ToArray();
+                }
                 
-                var serialized = serializer.ToBinary(di);
-                var ex = Assert.Throws<SerializationException>(() => serializer.FromBinary<DirectoryInfo>(serialized));
+                var ex = Assert.Throws<SerializationException>(() => deserializer.FromBinary<DirectoryInfo>(serialized));
                 ex.InnerException.Should().BeOfType<EvilDeserializationException>();
             }
             finally

--- a/src/Hyperion.Benchmarks/TypeRejectionBenchmark.cs
+++ b/src/Hyperion.Benchmarks/TypeRejectionBenchmark.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Hyperion.Internal;
+
+namespace Hyperion.Benchmarks
+{
+    [Config(typeof(HyperionConfig))]
+    public class TypeRejectionBenchmark
+    {
+        private Serializer _serializer;
+        private Stream _dangerousStream;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var di = new DirectoryInfo("C:\\Windows\\Windows32");
+            var serializer = new Serializer(SerializerOptions.Default.WithDisallowUnsafeType(false));
+            _dangerousStream = new MemoryStream();
+            serializer.Serialize(di, _dangerousStream);
+
+            _serializer = new Serializer();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _dangerousStream.Dispose();
+        }
+        
+        [Benchmark]
+        public void DeserializeDanger()
+        {
+            _dangerousStream.Position = 0;
+            try
+            {
+                _serializer.Deserialize<DirectoryInfo>(_dangerousStream);
+            }
+            catch(EvilDeserializationException)
+            {
+                // no-op
+            }
+        }
+        
+    }
+}

--- a/src/Hyperion/Extensions/StreamEx.cs
+++ b/src/Hyperion/Extensions/StreamEx.cs
@@ -172,6 +172,26 @@ namespace Hyperion.Extensions
             return value;
         }
 
+        internal static ByteArrayKey? ReadByteArrayKey(this Stream stream, DeserializerSession session)
+        {
+            var length = stream.ReadByte();
+            switch (length)
+            {
+                case 0:
+                    return null;
+                case 255:
+                    length = stream.ReadInt32(session);
+                    break;
+                default:
+                    length--;
+                    break;
+            }
+
+            var buffer = new byte[length];
+            stream.ReadFull(buffer, 0, length);
+            return new ByteArrayKey(buffer);
+        }
+
         public static string ReadString(this Stream stream, DeserializerSession session)
         {
             var length = stream.ReadByte();

--- a/src/Hyperion/Extensions/TypeEx.cs
+++ b/src/Hyperion/Extensions/TypeEx.cs
@@ -150,26 +150,52 @@ namespace Hyperion.Extensions
         {
             var bytes = stream.ReadLengthEncodedByteArray(session);
             var byteArr = ByteArrayKey.Create(bytes);
-            return session.Serializer.TypeNameLookup.GetOrAdd(byteArr, b =>
+
+            // Read possible rejected keys from the cache
+            if(session.Serializer.RejectedKeys.Contains(byteArr))
+                throw new EvilDeserializationException(
+                    "Unsafe Type Deserialization Detected!",
+                    StringEx.FromUtf8Bytes(byteArr.Bytes, 0, byteArr.Bytes.Length));
+            if(session.Serializer.UserRejectedKeys.Contains(byteArr))
+                throw new UserEvilDeserializationException(
+                    "Unsafe Type Deserialization Detected!", 
+                    StringEx.FromUtf8Bytes(byteArr.Bytes, 0, byteArr.Bytes.Length));
+
+            try
             {
-                var shortName = StringEx.FromUtf8Bytes(b.Bytes, 0, b.Bytes.Length);
-                var overrides = session.Serializer.Options.CrossFrameworkPackageNameOverrides;
-
-                var oldName = shortName;
-                foreach (var adapter in overrides)
+                return session.Serializer.TypeNameLookup.GetOrAdd(byteArr, b =>
                 {
-                    shortName = adapter(shortName);
-                    if (!ReferenceEquals(oldName, shortName))
-                        break;
-                }
+                    var shortName = StringEx.FromUtf8Bytes(b.Bytes, 0, b.Bytes.Length);
+                    var overrides = session.Serializer.Options.CrossFrameworkPackageNameOverrides;
 
-                var options = session.Serializer.Options;
-                return LoadTypeByName(shortName, options.DisallowUnsafeTypes, options.TypeFilter);
-            });
+                    var oldName = shortName;
+                    foreach (var adapter in overrides)
+                    {
+                        shortName = adapter(shortName);
+                        if (!ReferenceEquals(oldName, shortName))
+                            break;
+                    }
+
+                    var options = session.Serializer.Options;
+                    return LoadTypeByName(shortName, options.DisallowUnsafeTypes, options.TypeFilter);
+                });
+            }
+            catch (UserEvilDeserializationException)
+            {
+                // Store rejected types in the cache (optimization)
+                session.Serializer.UserRejectedKeys.Add(byteArr);
+                throw;
+            }
+            catch (EvilDeserializationException)
+            {
+                // Store rejected types in the cache (optimization)
+                session.Serializer.RejectedKeys.Add(byteArr);
+                throw;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool UnsafeInheritanceCheck(Type type)
+        internal static bool UnsafeInheritanceCheck(Type type)
         {
 #if NETSTANDARD1_6
             if (type.IsValueType())


### PR DESCRIPTION
Fixes #303

## Changes

* Make sure that type checking is done in deserialization
* Cache rejected types for optimization
* Add type cache cross-pollination spec

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

Only running the full benchmark on net471 because it takes way too long to run it on all platforms

``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1415 (2004/May2020Update/20H1)
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
```

#### net471

|                        Method |       Mean |    Error |   StdDev |        Min |        Max |        Op/s |  Gen 0 | Allocated |
|------------------------------ |-----------:|---------:|---------:|-----------:|-----------:|------------:|-------:|----------:|
|             Cyclic_References |   999.1 ns | 14.92 ns | 12.46 ns |   981.3 ns | 1,023.7 ns | 1,000,875.5 | 0.1888 |      1 KB |
|    Filtered_Cyclic_References |   984.8 ns |  7.16 ns |  5.98 ns |   976.8 ns |   998.5 ns | 1,015,423.0 | 0.1888 |      1 KB |
|               Virtual_Classes |   756.5 ns |  7.73 ns |  7.23 ns |   746.2 ns |   771.0 ns | 1,321,848.0 | 0.1850 |      1 KB |
|      Filtered_Virtual_Classes |   752.2 ns |  8.33 ns |  7.38 ns |   741.1 ns |   769.6 ns | 1,329,466.9 | 0.1850 |      1 KB |
|          Large_Sealed_Classes | 3,574.7 ns | 41.93 ns | 37.17 ns | 3,523.8 ns | 3,664.2 ns |   279,746.1 | 0.4349 |      3 KB |
| Filtered_Large_Sealed_Classes | 3,378.7 ns | 17.89 ns | 15.85 ns | 3,359.7 ns | 3,407.4 ns |   295,971.3 | 0.4311 |      3 KB |
|               Generic_Classes | 1,940.7 ns | 19.74 ns | 17.50 ns | 1,914.8 ns | 1,969.0 ns |   515,265.6 | 0.2174 |      1 KB |
|      Filtered_Generic_Classes | 1,933.6 ns | 18.63 ns | 15.56 ns | 1,915.8 ns | 1,964.2 ns |   517,167.6 | 0.2174 |      1 KB |

|       Method |        Mean |     Error |    StdDev |         Min |         Max |        Op/s |  Gen 0 | Allocated |
|------------- |------------:|----------:|----------:|------------:|------------:|------------:|-------:|----------:|
|   Byte_Array |    205.3 ns |   3.95 ns |   3.88 ns |    200.5 ns |    214.8 ns | 4,870,315.7 | 0.0420 |     265 B |
| String_Array |  1,230.7 ns |   8.44 ns |   7.48 ns |  1,220.6 ns |  1,245.2 ns |   812,544.5 | 0.0877 |     562 B |
|   Dictionary |  4,209.5 ns |  26.47 ns |  23.46 ns |  4,165.9 ns |  4,242.3 ns |   237,556.9 | 0.4044 |   2,576 B |
|   Array_List |  1,778.7 ns |  11.45 ns |  10.71 ns |  1,765.9 ns |  1,802.5 ns |   562,192.6 | 0.1926 |   1,220 B |
|  Linked_List |  8,377.6 ns |  64.67 ns |  54.00 ns |  8,289.5 ns |  8,448.1 ns |   119,365.7 | 0.8240 |   5,224 B |
|     Hash_Set | 10,698.2 ns | 159.82 ns | 149.49 ns | 10,481.7 ns | 10,898.9 ns |    93,473.8 | 1.0376 |   6,588 B |
|   Sorted_Set | 13,588.9 ns | 129.34 ns | 120.99 ns | 13,419.6 ns | 13,816.7 ns |    73,589.4 | 1.0986 |   6,950 B |

|               Method |     Mean |     Error |    StdDev |      Min |      Max |      Op/s |  Gen 0 | Allocated |
|--------------------- |---------:|----------:|----------:|---------:|---------:|----------:|-------:|----------:|
|      Immutable_Array | 2.416 μs | 0.0284 μs | 0.0252 μs | 2.384 μs | 2.468 μs | 413,844.2 | 0.1869 |      1 KB |
|       Immutable_List | 3.184 μs | 0.0183 μs | 0.0153 μs | 3.166 μs | 3.220 μs | 314,062.4 | 0.2556 |      2 KB |
|   Immutable_Hash_Set | 5.529 μs | 0.0487 μs | 0.0406 μs | 5.480 μs | 5.627 μs | 180,875.2 | 0.2899 |      2 KB |
| Immutable_Sorted_Set | 7.712 μs | 0.0355 μs | 0.0332 μs | 7.659 μs | 7.761 μs | 129,666.2 | 0.2899 |      2 KB |
| Immutable_Dictionary | 7.492 μs | 0.1225 μs | 0.1146 μs | 7.381 μs | 7.705 μs | 133,469.4 | 0.4578 |      3 KB |

|      Method |         Mean |      Error |     StdDev |          Min |          Max |         Op/s |  Gen 0 | Allocated |
|------------ |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|-------:|----------:|
|     Boolean |     94.82 ns |   0.713 ns |   0.632 ns |     93.94 ns |     95.80 ns | 10,546,162.9 | 0.0395 |     249 B |
|        Byte |    101.93 ns |   1.467 ns |   1.372 ns |     99.58 ns |    104.70 ns |  9,810,485.9 | 0.0395 |     249 B |
|       SByte |     92.98 ns |   0.971 ns |   0.908 ns |     91.60 ns |     94.92 ns | 10,755,476.4 | 0.0395 |     249 B |
|       Int16 |    124.60 ns |   2.442 ns |   2.714 ns |    120.70 ns |    129.74 ns |  8,025,547.9 | 0.0393 |     249 B |
|      UInt16 |    125.95 ns |   2.532 ns |   2.487 ns |    122.48 ns |    130.39 ns |  7,939,711.9 | 0.0393 |     249 B |
|       Int32 |    130.70 ns |   2.631 ns |   3.030 ns |    125.74 ns |    136.38 ns |  7,651,315.1 | 0.0393 |     249 B |
|      UInt32 |    130.76 ns |   1.588 ns |   1.408 ns |    127.48 ns |    133.10 ns |  7,647,306.6 | 0.0393 |     249 B |
|       Int64 |    139.67 ns |   2.755 ns |   3.678 ns |    133.60 ns |    147.36 ns |  7,159,983.1 | 0.0393 |     249 B |
|      UInt64 |    141.45 ns |   1.056 ns |   0.988 ns |    139.86 ns |    143.38 ns |  7,069,557.4 | 0.0393 |     249 B |
|      Single |    132.79 ns |   2.575 ns |   2.862 ns |    128.02 ns |    138.19 ns |  7,530,469.8 | 0.0393 |     249 B |
|      Double |    141.20 ns |   2.720 ns |   3.132 ns |    136.66 ns |    148.11 ns |  7,082,156.8 | 0.0393 |     249 B |
|     Decimal |    219.53 ns |   4.265 ns |   5.077 ns |    211.56 ns |    230.66 ns |  4,555,192.1 | 0.0546 |     345 B |
|       Guids |    136.55 ns |   2.633 ns |   2.817 ns |    132.27 ns |    142.65 ns |  7,323,434.2 | 0.0546 |     345 B |
|   DateTimes |    139.89 ns |   1.894 ns |   1.582 ns |    137.66 ns |    143.59 ns |  7,148,728.2 | 0.0393 |     249 B |
|    TimeSpan |    364.08 ns |   5.551 ns |   4.635 ns |    355.83 ns |    370.90 ns |  2,746,645.7 | 0.0887 |     562 B |
|      String |    358.33 ns |   6.938 ns |   8.521 ns |    345.66 ns |    374.87 ns |  2,790,715.2 | 0.1092 |     690 B |
|        Type |  7,656.71 ns | 143.389 ns | 127.111 ns |  7,503.31 ns |  7,901.38 ns |    130,604.5 | 1.4191 |   9,035 B |
|      Tuple1 |    774.22 ns |   5.718 ns |   4.464 ns |    768.82 ns |    781.47 ns |  1,291,617.8 | 0.0973 |     618 B |
|      Tuple2 |  1,220.96 ns |  23.291 ns |  23.918 ns |  1,183.51 ns |  1,256.78 ns |    819,030.1 | 0.1278 |     818 B |
|      Tuple3 |  1,482.96 ns |   9.821 ns |   8.706 ns |  1,469.04 ns |  1,496.90 ns |    674,325.0 | 0.1373 |     875 B |
|      Tuple4 |  9,758.73 ns | 188.950 ns | 176.744 ns |  9,564.00 ns | 10,187.09 ns |    102,472.3 | 1.5411 |   9,773 B |
|      Tuple5 | 10,197.37 ns | 130.596 ns | 122.160 ns | 10,065.48 ns | 10,460.89 ns |     98,064.5 | 1.5564 |   9,845 B |
|      Tuple6 | 10,526.17 ns | 135.309 ns | 126.568 ns | 10,354.37 ns | 10,787.10 ns |     95,001.3 | 1.5564 |   9,918 B |
|      Tuple7 | 11,208.14 ns | 133.347 ns | 124.733 ns | 10,989.25 ns | 11,386.32 ns |     89,220.9 | 1.6174 |  10,279 B |
|      Tuple8 | 12,800.57 ns | 184.064 ns | 172.174 ns | 12,557.06 ns | 13,074.56 ns |     78,121.5 | 1.7090 |  10,816 B |
| ValueTuple1 |    385.65 ns |   7.262 ns |   6.793 ns |    374.33 ns |    397.36 ns |  2,593,008.0 | 0.0954 |     602 B |
| ValueTuple2 |    633.65 ns |  12.488 ns |  12.825 ns |    620.00 ns |    655.74 ns |  1,578,150.3 | 0.1259 |     794 B |
| ValueTuple3 |    674.46 ns |  13.302 ns |  13.660 ns |    659.46 ns |    702.71 ns |  1,482,669.6 | 0.1307 |     826 B |
| ValueTuple4 |  8,575.00 ns | 115.887 ns | 108.401 ns |  8,433.04 ns |  8,818.48 ns |    116,618.1 | 1.5259 |   9,725 B |
| ValueTuple5 |  8,718.89 ns |  82.873 ns |  73.465 ns |  8,611.45 ns |  8,868.61 ns |    114,693.5 | 1.5411 |   9,773 B |
| ValueTuple6 |  8,669.16 ns | 135.303 ns | 126.562 ns |  8,470.87 ns |  8,947.96 ns |    115,351.5 | 1.5564 |   9,829 B |
| ValueTuple7 |  9,263.20 ns | 112.451 ns | 105.187 ns |  9,115.36 ns |  9,444.26 ns |    107,954.1 | 1.6022 |  10,158 B |
| ValueTuple8 |  9,816.24 ns | 159.390 ns | 149.093 ns |  9,618.80 ns | 10,094.86 ns |    101,872.0 | 1.6937 |  10,728 B |

|                         Method |       Mean |    Error |   StdDev |        Min |        Max |        Op/s |  Gen 0 | Allocated |
|------------------------------- |-----------:|---------:|---------:|-----------:|-----------:|------------:|-------:|----------:|
|                          Enums |   365.6 ns |  6.46 ns |  6.05 ns |   358.6 ns |   377.1 ns | 2,735,443.4 | 0.0925 |     586 B |
|                 Filtered_Enums |   364.4 ns |  5.50 ns |  4.88 ns |   354.6 ns |   373.3 ns | 2,744,029.3 | 0.0925 |     586 B |
|           Standard_Value_Types | 1,174.9 ns | 22.72 ns | 25.25 ns | 1,140.6 ns | 1,219.5 ns |   851,153.1 | 0.1163 |     738 B |
|  Filtered_Standard_Value_Types | 1,175.1 ns | 22.36 ns | 22.96 ns | 1,146.7 ns | 1,205.8 ns |   850,979.7 | 0.1163 |     738 B |
|          Blittable_Value_Types |   722.7 ns | 14.41 ns | 16.60 ns |   700.3 ns |   748.1 ns | 1,383,733.3 | 0.1001 |     634 B |
| Filtered_Blittable_Value_Types |   721.1 ns | 14.44 ns | 13.51 ns |   704.5 ns |   747.7 ns | 1,386,738.9 | 0.1001 |     634 B |

|            Method |     Mean |    Error |   StdDev |      Min |      Max |     Op/s |  Gen 0 | Allocated |
|------------------ |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| DeserializeDanger | 21.45 μs | 0.260 μs | 0.243 μs | 21.22 μs | 21.96 μs | 46,622.5 | 0.3052 |      2 KB |

#### netcoreapp3.1

|            Method |     Mean |    Error |   StdDev |      Min |      Max |     Op/s |  Gen 0 | Allocated |
|------------------ |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| DeserializeDanger | 18.17 μs | 0.325 μs | 0.304 μs | 17.79 μs | 18.62 μs | 55,046.9 | 0.2136 |      2 KB |

#### net6.0

|            Method |     Mean |    Error |   StdDev |      Min |      Max |     Op/s |  Gen 0 | Allocated |
|------------------ |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| DeserializeDanger | 17.81 μs | 0.343 μs | 0.481 μs | 17.13 μs | 18.58 μs | 56,156.1 | 0.2136 |      2 KB |

### This PR's Benchmarks

Only running the full benchmark on net471 because it takes way too long to run it on all platforms

``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19041.1415 (2004/May2020Update/20H1)
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
```
### net471

|                        Method |       Mean |    Error |   StdDev |        Min |        Max |        Op/s |  Gen 0 | Allocated |
|------------------------------ |-----------:|---------:|---------:|-----------:|-----------:|------------:|-------:|----------:|
|             Cyclic_References | 1,001.1 ns | 13.06 ns | 12.22 ns |   980.0 ns | 1,026.1 ns |   998,942.7 | 0.1888 |      1 KB |
|    Filtered_Cyclic_References | 1,009.9 ns | 20.04 ns | 22.27 ns |   982.6 ns | 1,064.7 ns |   990,178.6 | 0.1888 |      1 KB |
|               Virtual_Classes |   775.0 ns |  6.47 ns |  6.05 ns |   764.7 ns |   782.8 ns | 1,290,332.3 | 0.1850 |      1 KB |
|      Filtered_Virtual_Classes |   778.8 ns | 14.88 ns | 15.93 ns |   761.2 ns |   807.5 ns | 1,283,966.2 | 0.1850 |      1 KB |
|          Large_Sealed_Classes | 3,471.9 ns | 53.92 ns | 50.44 ns | 3,421.3 ns | 3,566.6 ns |   288,026.4 | 0.4311 |      3 KB |
| Filtered_Large_Sealed_Classes | 3,520.1 ns | 70.18 ns | 65.65 ns | 3,463.1 ns | 3,627.9 ns |   284,079.2 | 0.4349 |      3 KB |
|               Generic_Classes | 1,946.4 ns | 15.05 ns | 14.08 ns | 1,919.8 ns | 1,969.0 ns |   513,773.7 | 0.2174 |      1 KB |
|      Filtered_Generic_Classes | 1,976.1 ns | 38.96 ns | 41.69 ns | 1,921.4 ns | 2,038.9 ns |   506,045.1 | 0.2174 |      1 KB |

|       Method |        Mean |     Error |    StdDev |         Min |         Max |        Op/s |  Gen 0 | Allocated |
|------------- |------------:|----------:|----------:|------------:|------------:|------------:|-------:|----------:|
|   Byte_Array |    202.3 ns |   1.78 ns |   1.66 ns |    200.1 ns |    205.4 ns | 4,943,531.8 | 0.0420 |     265 B |
| String_Array |  1,179.5 ns |   4.78 ns |   3.99 ns |  1,170.9 ns |  1,186.1 ns |   847,783.1 | 0.0877 |     562 B |
|   Dictionary |  4,182.2 ns |  31.60 ns |  29.56 ns |  4,156.5 ns |  4,245.3 ns |   239,107.7 | 0.4044 |   2,576 B |
|   Array_List |  1,754.1 ns |   7.84 ns |   6.55 ns |  1,743.4 ns |  1,763.5 ns |   570,081.6 | 0.1926 |   1,220 B |
|  Linked_List |  8,388.5 ns |  65.44 ns |  61.21 ns |  8,264.3 ns |  8,473.9 ns |   119,210.2 | 0.8240 |   5,224 B |
|     Hash_Set | 10,550.0 ns | 197.99 ns | 194.46 ns | 10,387.6 ns | 10,932.9 ns |    94,786.9 | 1.0376 |   6,588 B |
|   Sorted_Set | 13,416.2 ns |  63.84 ns |  59.72 ns | 13,331.0 ns | 13,549.0 ns |    74,537.0 | 1.0986 |   6,950 B |

|               Method |     Mean |     Error |    StdDev |      Min |      Max |      Op/s |  Gen 0 | Allocated |
|--------------------- |---------:|----------:|----------:|---------:|---------:|----------:|-------:|----------:|
|      Immutable_Array | 2.318 μs | 0.0126 μs | 0.0105 μs | 2.305 μs | 2.344 μs | 431,410.3 | 0.1869 |      1 KB |
|       Immutable_List | 3.189 μs | 0.0205 μs | 0.0191 μs | 3.152 μs | 3.216 μs | 313,567.4 | 0.2556 |      2 KB |
|   Immutable_Hash_Set | 5.454 μs | 0.0397 μs | 0.0352 μs | 5.418 μs | 5.518 μs | 183,357.7 | 0.2899 |      2 KB |
| Immutable_Sorted_Set | 7.709 μs | 0.0273 μs | 0.0228 μs | 7.657 μs | 7.740 μs | 129,720.1 | 0.2899 |      2 KB |
| Immutable_Dictionary | 7.424 μs | 0.1125 μs | 0.1052 μs | 7.316 μs | 7.616 μs | 134,693.8 | 0.4578 |      3 KB |

|      Method |         Mean |      Error |     StdDev |          Min |          Max |         Op/s |  Gen 0 | Allocated |
|------------ |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|-------:|----------:|
|     Boolean |     94.53 ns |   1.026 ns |   0.960 ns |     93.12 ns |     96.50 ns | 10,578,713.9 | 0.0395 |     249 B |
|        Byte |    100.50 ns |   0.609 ns |   0.540 ns |     99.63 ns |    101.54 ns |  9,950,065.6 | 0.0395 |     249 B |
|       SByte |     92.57 ns |   0.729 ns |   0.647 ns |     91.83 ns |     94.05 ns | 10,802,311.4 | 0.0395 |     249 B |
|       Int16 |    131.21 ns |   2.598 ns |   2.992 ns |    126.09 ns |    137.67 ns |  7,621,480.7 | 0.0393 |     249 B |
|      UInt16 |    136.00 ns |   2.342 ns |   2.191 ns |    132.03 ns |    139.31 ns |  7,353,060.9 | 0.0393 |     249 B |
|       Int32 |    137.73 ns |   1.432 ns |   1.340 ns |    135.60 ns |    140.05 ns |  7,260,675.4 | 0.0393 |     249 B |
|      UInt32 |    127.42 ns |   1.794 ns |   1.591 ns |    124.98 ns |    129.99 ns |  7,848,159.1 | 0.0393 |     249 B |
|       Int64 |    138.72 ns |   1.224 ns |   1.145 ns |    135.94 ns |    140.15 ns |  7,208,811.8 | 0.0393 |     249 B |
|      UInt64 |    151.44 ns |   3.018 ns |   3.475 ns |    146.91 ns |    158.09 ns |  6,603,275.6 | 0.0393 |     249 B |
|      Single |    131.75 ns |   0.996 ns |   0.883 ns |    130.43 ns |    133.36 ns |  7,590,352.0 | 0.0393 |     249 B |
|      Double |    151.75 ns |   2.940 ns |   2.887 ns |    147.61 ns |    157.42 ns |  6,589,630.0 | 0.0393 |     249 B |
|     Decimal |    199.31 ns |   3.827 ns |   3.758 ns |    195.08 ns |    207.83 ns |  5,017,215.7 | 0.0546 |     345 B |
|       Guids |    131.51 ns |   1.645 ns |   1.459 ns |    129.24 ns |    134.23 ns |  7,603,813.2 | 0.0546 |     345 B |
|   DateTimes |    141.62 ns |   2.856 ns |   2.671 ns |    139.13 ns |    147.43 ns |  7,061,231.7 | 0.0393 |     249 B |
|    TimeSpan |    378.67 ns |   7.283 ns |   6.813 ns |    370.17 ns |    392.11 ns |  2,640,817.2 | 0.0887 |     562 B |
|      String |    350.38 ns |   5.252 ns |   4.656 ns |    341.99 ns |    360.85 ns |  2,854,019.5 | 0.1092 |     690 B |
|        Type |  7,502.33 ns | 103.625 ns |  91.861 ns |  7,384.24 ns |  7,691.81 ns |    133,291.9 | 1.4267 |   9,035 B |
|      Tuple1 |    808.89 ns |  15.628 ns |  16.049 ns |    792.27 ns |    835.23 ns |  1,236,254.5 | 0.0973 |     618 B |
|      Tuple2 |  1,237.52 ns |  24.564 ns |  25.225 ns |  1,208.65 ns |  1,277.32 ns |    808,070.3 | 0.1278 |     818 B |
|      Tuple3 |  1,512.52 ns |  29.374 ns |  27.477 ns |  1,484.81 ns |  1,559.44 ns |    661,146.9 | 0.1373 |     875 B |
|      Tuple4 |  9,609.46 ns | 166.237 ns | 155.498 ns |  9,389.88 ns |  9,861.36 ns |    104,064.1 | 1.5411 |   9,765 B |
|      Tuple5 | 10,115.73 ns | 180.997 ns | 169.305 ns |  9,904.83 ns | 10,423.69 ns |     98,856.0 | 1.5564 |   9,837 B |
|      Tuple6 | 10,676.43 ns | 195.882 ns | 183.228 ns | 10,397.76 ns | 10,994.23 ns |     93,664.3 | 1.5564 |   9,910 B |
|      Tuple7 | 11,315.51 ns | 218.065 ns | 203.978 ns | 11,085.60 ns | 11,658.12 ns |     88,374.3 | 1.6174 |  10,271 B |
|      Tuple8 | 12,589.04 ns | 199.844 ns | 222.126 ns | 12,126.27 ns | 13,020.79 ns |     79,434.2 | 1.7090 |  10,808 B |
| ValueTuple1 |    410.40 ns |   4.193 ns |   3.717 ns |    405.01 ns |    419.66 ns |  2,436,630.9 | 0.0954 |     602 B |
| ValueTuple2 |    624.80 ns |   4.656 ns |   4.355 ns |    618.30 ns |    633.48 ns |  1,600,522.6 | 0.1259 |     794 B |
| ValueTuple3 |    721.48 ns |   4.384 ns |   4.101 ns |    715.29 ns |    728.86 ns |  1,386,048.3 | 0.1307 |     826 B |
| ValueTuple4 |  8,804.24 ns |  99.733 ns |  93.290 ns |  8,538.89 ns |  8,907.92 ns |    113,581.7 | 1.5259 |   9,717 B |
| ValueTuple5 |  8,701.94 ns | 154.517 ns | 144.535 ns |  8,456.11 ns |  9,002.77 ns |    114,916.9 | 1.5411 |   9,765 B |
| ValueTuple6 |  8,738.47 ns |  70.874 ns |  66.295 ns |  8,620.41 ns |  8,848.17 ns |    114,436.5 | 1.5411 |   9,821 B |
| ValueTuple7 |  9,261.06 ns | 178.901 ns | 183.718 ns |  9,042.14 ns |  9,732.79 ns |    107,979.0 | 1.6022 |  10,150 B |
| ValueTuple8 |  9,791.43 ns |  85.571 ns |  75.856 ns |  9,662.15 ns |  9,934.00 ns |    102,130.2 | 1.6937 |  10,720 B |

|                         Method |       Mean |    Error |   StdDev |        Min |        Max |        Op/s |  Gen 0 | Allocated |
|------------------------------- |-----------:|---------:|---------:|-----------:|-----------:|------------:|-------:|----------:|
|                          Enums |   379.1 ns |  3.94 ns |  3.68 ns |   373.5 ns |   386.6 ns | 2,637,578.0 | 0.0925 |     586 B |
|                 Filtered_Enums |   379.6 ns |  5.01 ns |  4.44 ns |   374.1 ns |   389.2 ns | 2,634,429.5 | 0.0925 |     586 B |
|           Standard_Value_Types | 1,174.2 ns |  5.08 ns |  4.75 ns | 1,164.7 ns | 1,181.5 ns |   851,671.6 | 0.1163 |     738 B |
|  Filtered_Standard_Value_Types | 1,186.9 ns | 23.60 ns | 23.18 ns | 1,163.8 ns | 1,225.1 ns |   842,496.7 | 0.1163 |     738 B |
|          Blittable_Value_Types |   743.9 ns |  4.32 ns |  4.04 ns |   735.9 ns |   751.6 ns | 1,344,196.0 | 0.1001 |     634 B |
| Filtered_Blittable_Value_Types |   733.9 ns |  7.90 ns |  6.60 ns |   727.4 ns |   751.8 ns | 1,362,581.8 | 0.1001 |     634 B |

|            Method |     Mean |    Error |   StdDev |      Min |      Max |     Op/s |  Gen 0 | Allocated |
|------------------ |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| DeserializeDanger | 10.18 μs | 0.078 μs | 0.065 μs | 10.12 μs | 10.35 μs | 98,246.6 | 0.1831 |      1 KB |

### netcoreapp3.1

|            Method |     Mean |    Error |   StdDev |      Min |      Max |     Op/s |  Gen 0 | Allocated |
|------------------ |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| DeserializeDanger | 10.08 μs | 0.053 μs | 0.050 μs | 9.963 μs | 10.14 μs | 99,208.8 | 0.1221 |      1 KB |

### net6.0

|            Method |     Mean |     Error |    StdDev |      Min |      Max |      Op/s |  Gen 0 | Allocated |
|------------------ |---------:|----------:|----------:|---------:|---------:|----------:|-------:|----------:|
| DeserializeDanger | 9.622 μs | 0.1177 μs | 0.1101 μs | 9.492 μs | 9.855 μs | 103,929.2 | 0.1221 |      1 KB |

