### PR TITLE
Remove netstandard1.6 platform target

### DIFF
--- a/src/Hyperion.Benchmarks/Prolog.cs
+++ b/src/Hyperion.Benchmarks/Prolog.cs
@@ -21,9 +21,9 @@ namespace Hyperion.Benchmarks
     {
         public HyperionConfig()
         {
-            Add(StatisticColumn.Mean, StatisticColumn.Min, StatisticColumn.Max, StatisticColumn.OperationsPerSecond);
-            Add(MarkdownExporter.GitHub);
-            Add(MemoryDiagnoser.Default);
+            AddColumn(StatisticColumn.Mean, StatisticColumn.Min, StatisticColumn.Max, StatisticColumn.OperationsPerSecond);
+            AddExporter(MarkdownExporter.GitHub);
+            AddDiagnoser(MemoryDiagnoser.Default);
         }
     }
 

--- a/src/Hyperion.Benchmarks/SerializeClassesBenchmark.cs
+++ b/src/Hyperion.Benchmarks/SerializeClassesBenchmark.cs
@@ -25,7 +25,8 @@ namespace Hyperion.Benchmarks
         
         protected override void Init()
         {
-            var baseOptions = new SerializerOptions(preserveObjectReferences: true);
+            var baseOptions = SerializerOptions.Default
+                .WithPreserveObjectReferences(true);
             Serializer = new Serializer(baseOptions);
 
             var filteredOptions = baseOptions

--- a/src/Hyperion.Tests/Bugs.cs
+++ b/src/Hyperion.Tests/Bugs.cs
@@ -95,7 +95,9 @@ namespace Hyperion.Tests
         {
             var stream = new MemoryStream();
             var msg = new ByteMessage(DateTime.UtcNow, 1, 2);
-            var serializer = new Serializer(new SerializerOptions(versionTolerance: true, preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
             serializer.Serialize(msg, stream);
             stream.Position = 0;
             var res = serializer.Deserialize(stream);
@@ -107,7 +109,9 @@ namespace Hyperion.Tests
         [Fact]
         public void CanFindTypeByManifest_WhenManifestContainsUnknownAssemblyVersion()
         {
-            var serializer = new Serializer(new SerializerOptions(versionTolerance: true, preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
             var type = typeof(ByteMessage);
             
             MemoryStream GetStreamForManifest(string manifest)
@@ -168,7 +172,9 @@ namespace Hyperion.Tests
         public void CanSerialieCustomType_bug()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(versionTolerance: true, preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
             var root = new Recover(SnapshotSelectionCriteria.Latest);
 
             serializer.Serialize(root, stream);
@@ -179,7 +185,9 @@ namespace Hyperion.Tests
         [Fact]
         public void CanSerializeImmutableGenericInterfaces()
         {
-            var serializer = new Serializer(new SerializerOptions(versionTolerance: true, preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
             var names = new List<Container<string>>
             {
                 new Container<string>("Mr", TrustLevel.Partial),
@@ -210,7 +218,9 @@ namespace Hyperion.Tests
         {
             var stream = new MemoryStream();
             var msg = new Uri("http://localhost:9202/", UriKind.RelativeOrAbsolute);
-            var serializer = new Serializer(new SerializerOptions(preserveObjectReferences: true, versionTolerance: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
             serializer.Serialize(msg, stream);
             stream.Position = 0;
             var res = serializer.Deserialize(stream);
@@ -458,7 +468,7 @@ namespace Hyperion.Tests
                     { 42, "iMaGiNe" }
                 }.ToImmutableDictionary(),
             };
-            var serializer = new Serializer(new SerializerOptions(knownTypes: new[]
+            var serializer = new Serializer(SerializerOptions.Default.WithKnownTypes(new[]
             {
                 typeof(object[]),
                 typeof(int[]),
@@ -494,8 +504,11 @@ namespace Hyperion.Tests
 
         class FieldsToOrder
         {
+#pragma warning disable CS0649
             public string A2;
+            // ReSharper disable once InconsistentNaming
             public string a1;
+#pragma warning restore CS0649
         }
 
         [Fact]

--- a/src/Hyperion.Tests/CollectionTests.cs
+++ b/src/Hyperion.Tests/CollectionTests.cs
@@ -398,7 +398,9 @@ namespace Hyperion.Tests
         public void Issue18()
         {
             var msg = new byte[] {1, 2, 3, 4};
-            var serializer = new Serializer(new SerializerOptions(true, true));
+            var serializer = new Serializer(SerializerOptions.Default
+	            .WithVersionTolerance(true)
+	            .WithPreserveObjectReferences(true));
 
             byte[] serialized;
             using (var ms = new MemoryStream())
@@ -420,9 +422,9 @@ namespace Hyperion.Tests
         public void Issue263_CanSerializeArrayOfSurrogate_WhenPreservingObjectReference()
         {
 	        var invoked = new List<SurrogatedClass.ClassSurrogate>();
-	        var serializer = new Serializer(new SerializerOptions(
-		        preserveObjectReferences: true, 
-		        surrogates: new []
+	        var serializer = new Serializer(SerializerOptions.Default
+		        .WithPreserveObjectReferences(true)
+		        .WithSurrogates(new []
 		        {
 			        Surrogate.Create<SurrogatedClass, SurrogatedClass.ClassSurrogate>( 
 				        to => to.ToSurrogate(),
@@ -562,7 +564,9 @@ namespace Hyperion.Tests
 
 		public abstract class BaseContainer : IList<NotKnown>, ICollection<NotKnown>, IEnumerable<NotKnown>, IEnumerable, IList, ICollection
 		{
+#pragma warning disable CS0649
 			private List<NotKnown> _inner;
+#pragma warning restore CS0649
 
 			#region interfaces methods
 
@@ -663,9 +667,9 @@ namespace Hyperion.Tests
 	    [Fact]
 	    public void CanInstantiateSerializerForCollectionWithAmbiguousAddMethod()
 	    {
-		    var serializer = new Serializer(
-			    new SerializerOptions(knownTypes: new List<Type> {typeof(DerivedContainer)},
-				    serializerFactories: new List<ValueSerializerFactory> {new DerivedContainerSerializerFactory()}));
+		    var serializer = new Serializer(SerializerOptions.Default
+			    .WithKnownTypes(new List<Type> {typeof(DerivedContainer)})
+			    .WithSerializerFactory(new List<ValueSerializerFactory> {new DerivedContainerSerializerFactory()}));
 		    var init = new DerivedContainer();
 		    serializer.Serialize(init, new MemoryStream());
 		    // we're done if AmbiguousMatchException wasn't fired

--- a/src/Hyperion.Tests/CustomObjectTests.cs
+++ b/src/Hyperion.Tests/CustomObjectTests.cs
@@ -222,7 +222,7 @@ namespace Hyperion.Tests
         [Fact]
         public void CanSerializeObjectsKnownTypes()
         {
-            CustomInit(new Serializer(new SerializerOptions(knownTypes: new[] { typeof(Something) })));
+            CustomInit(new Serializer(SerializerOptions.Default.WithKnownTypes(new[] { typeof(Something) })));
             var expected1 = new Something
             {
                 StringProp = "First"

--- a/src/Hyperion.Tests/CyclicTests.cs
+++ b/src/Hyperion.Tests/CyclicTests.cs
@@ -19,7 +19,9 @@ namespace Hyperion.Tests
         public void CanSerializeDeepCyclicReferences()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(versionTolerance: true, preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
             var root = new Root();
             var bar = new Bar();
             bar.Self = bar;
@@ -40,7 +42,9 @@ namespace Hyperion.Tests
         public void CanSerializeDictionaryPreserveObjectReferences()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(versionTolerance: true, preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
 
             var arr1 = new[] {1, 2, 3};
             var arr2 = new[] { 1, 2, 3 };
@@ -64,7 +68,9 @@ namespace Hyperion.Tests
         public void CanSerializeDictionaryPreserveObjectReferences2()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(versionTolerance: true, preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
 
             var val = new List<string> { "first", "second" };
 
@@ -91,7 +97,9 @@ namespace Hyperion.Tests
         public void CanSerializeCyclicReferences()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(versionTolerance: true, preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default
+                .WithVersionTolerance(true)
+                .WithPreserveObjectReferences(true));
             var bar = new Bar();
             bar.Self = bar;
             bar.XYZ = 234;
@@ -107,7 +115,7 @@ namespace Hyperion.Tests
         public void CanSerializeMultiLevelCyclicReferences()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default.WithPreserveObjectReferences(true));
             var a = new A();
             var b = new B();
             a.B = b;

--- a/src/Hyperion.Tests/DelegateTests.cs
+++ b/src/Hyperion.Tests/DelegateTests.cs
@@ -34,7 +34,7 @@ namespace Hyperion.Tests
         public void CanSerializeMemberMethod()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions());
+            var serializer = new Serializer(SerializerOptions.Default);
 
             Func<string> a = 123.ToString;
             serializer.Serialize(a, stream);
@@ -49,7 +49,7 @@ namespace Hyperion.Tests
         public void CanSerializeDelegate()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions());
+            var serializer = new Serializer(SerializerOptions.Default);
 
             Action<Dummy> a = dummy => dummy.Prop = 1;
             serializer.Serialize(a,stream);
@@ -71,7 +71,7 @@ namespace Hyperion.Tests
         public void CanSerializeStaticDelegate()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions());
+            var serializer = new Serializer(SerializerOptions.Default);
 
             Func<int, int> fun = StaticFunc;
 
@@ -88,7 +88,7 @@ namespace Hyperion.Tests
         public void CanSerializeObjectWithClosure()
         {
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions());
+            var serializer = new Serializer(SerializerOptions.Default);
 
             var hasClosure = new HasClosure();
             hasClosure.Create();

--- a/src/Hyperion.Tests/ExpressionTests.cs
+++ b/src/Hyperion.Tests/ExpressionTests.cs
@@ -478,7 +478,7 @@ namespace Hyperion.Tests
         [Fact]
         public void CanSerializeLambdaExpressionContainingGenericMethod() {
             Expression<Func<Dummy, bool>> expr = dummy => dummy.TestField.Contains('s');
-            var serializer = new Serializer(new SerializerOptions(preserveObjectReferences: true));
+            var serializer = new Serializer(SerializerOptions.Default.WithPreserveObjectReferences(true));
             using (var ms = new MemoryStream())
             {
                 serializer.Serialize(expr, ms);

--- a/src/Hyperion.Tests/IlCompilerTests.cs
+++ b/src/Hyperion.Tests/IlCompilerTests.cs
@@ -7,7 +7,6 @@
 // -----------------------------------------------------------------------
 #endregion
 
-#if NET45
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -67,7 +66,7 @@ namespace Hyperion.Tests
             var a = c.Compile();
             var dummy = new Dummy();
             a(dummy);
-            Assert.Equal(true, dummy.BoolField);
+            Assert.True(dummy.BoolField);
         }
 
         [Fact]
@@ -79,7 +78,7 @@ namespace Hyperion.Tests
             var a = c.Compile();
             var dummy = new Dummy();
             a(dummy);
-            Assert.Equal(true, dummy.BoolField);
+            Assert.True(dummy.BoolField);
         }
 
 
@@ -93,7 +92,7 @@ namespace Hyperion.Tests
             var a = c.Compile();
             var dummy = new Dummy();
             a(dummy);
-            Assert.Equal(true,dummy.BoolField);
+            Assert.True(dummy.BoolField);
         }
 
         [Fact]
@@ -112,7 +111,7 @@ namespace Hyperion.Tests
             c.Emit(b);
             var a = c.Compile();
             var res = a();
-            Assert.Equal(true,res);
+            Assert.True(res);
         }
 
         [Fact]
@@ -190,7 +189,7 @@ namespace Hyperion.Tests
         {
             var value = new FakeTupleString("Hello");
             var type = value.GetType();
-            var serializer = new Serializer(new SerializerOptions(knownTypes: new List<Type>() { type }));
+            var serializer = new Serializer(SerializerOptions.Default.WithKnownTypes(new List<Type>() { type }));
             var session = new DeserializerSession(serializer);
             var stream = new MemoryStream();
 
@@ -211,7 +210,7 @@ namespace Hyperion.Tests
         {
             var value = FSharpOption<string>.Some("abc");
             var type = value.GetType();
-            var serializer = new Serializer(new SerializerOptions(knownTypes: new List<Type>() { type }));
+            var serializer = new Serializer(SerializerOptions.Default.WithKnownTypes(new List<Type>() { type }));
             var session = new DeserializerSession(serializer);
             var stream = new MemoryStream();
 
@@ -230,7 +229,7 @@ namespace Hyperion.Tests
         {
             var value = Tuple.Create("Hello");
             var type = value.GetType();
-            var serializer = new Serializer(new SerializerOptions(knownTypes: new List<Type>() { type }));
+            var serializer = new Serializer(SerializerOptions.Default.WithKnownTypes(new List<Type>() { type }));
             var session = new DeserializerSession(serializer);
             var stream = new MemoryStream();
 
@@ -248,7 +247,7 @@ namespace Hyperion.Tests
         [Fact]
         public void ReadSimulation()
         {
-            var serializer = new Serializer(new SerializerOptions(knownTypes:new List<Type>() {typeof(Poco)}));
+            var serializer = new Serializer(SerializerOptions.Default.WithKnownTypes(new List<Type>() {typeof(Poco)}));
             var session = new DeserializerSession(serializer);
             var stream = new MemoryStream();
             var poco = new Poco()
@@ -306,4 +305,3 @@ namespace Hyperion.Tests
         }
     }
 }
-#endif

--- a/src/Hyperion.Tests/InterfaceTests.cs
+++ b/src/Hyperion.Tests/InterfaceTests.cs
@@ -43,7 +43,7 @@ namespace Hyperion.Tests
                 }
             };
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions());
+            var serializer = new Serializer(SerializerOptions.Default);
             serializer.Serialize(b, stream);
             stream.Position = 0;
             var res = serializer.Deserialize(stream);

--- a/src/Hyperion.Tests/SurrogateTests.cs
+++ b/src/Hyperion.Tests/SurrogateTests.cs
@@ -105,7 +105,7 @@ namespace Hyperion.Tests
                 })
             };
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(surrogates: surrogates));
+            var serializer = new Serializer(SerializerOptions.Default.WithSurrogates(surrogates));
             var foo = new Foo
             {
                 Bar = "I will be replaced!"
@@ -131,7 +131,7 @@ namespace Hyperion.Tests
                 })
             };
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(surrogates: surrogates));
+            var serializer = new Serializer(SerializerOptions.Default.WithSurrogates(surrogates));
             var foo = new Foo
             {
                 Bar = "I will be replaced!"
@@ -157,7 +157,7 @@ namespace Hyperion.Tests
                 })
             };
             var stream = new MemoryStream();
-            var serializer = new Serializer(new SerializerOptions(surrogates: surrogates));
+            var serializer = new Serializer(SerializerOptions.Default.WithSurrogates(surrogates));
             var key = new SurrogatedKey("test key");
             var foo = new Foo
             {

--- a/src/Hyperion.Tests/UnsupportedTypeSerializerTests.cs
+++ b/src/Hyperion.Tests/UnsupportedTypeSerializerTests.cs
@@ -63,10 +63,7 @@ namespace Hyperion.Tests
 
 
     /* Copied from MongoDB.Bson.BsonElement - causes failures in the serializer - not sure why */
-#if NET45
     [Serializable]
-#endif
-
     internal struct TestElement : IComparable<TestElement>, IEquatable<TestElement>
     {
         public TestElement(string name, string value)

--- a/src/Hyperion/Compilation/IlBuilder.cs
+++ b/src/Hyperion/Compilation/IlBuilder.cs
@@ -15,7 +15,6 @@ using Hyperion.Extensions;
 
 namespace Hyperion.Compilation
 {
-#if NET45
     internal class IlBuilder
     {
         private readonly List<IlExpression> _expressions = new List<IlExpression>();
@@ -181,5 +180,4 @@ namespace Hyperion.Compilation
             return _expressions.Count - 1;
         }
     }
-#endif
 }

--- a/src/Hyperion/Compilation/IlCompiler.cs
+++ b/src/Hyperion/Compilation/IlCompiler.cs
@@ -14,7 +14,6 @@ using System.Reflection.Emit;
 
 namespace Hyperion.Compilation
 {
-#if NET45
     internal sealed class IlCompiler<TDel> : IlBuilder, ICompiler<TDel>
     {
         public TDel Compile()
@@ -93,5 +92,4 @@ namespace Hyperion.Compilation
             return self;
         }
     }
-#endif
 }

--- a/src/Hyperion/Compilation/IlCompilerContext.cs
+++ b/src/Hyperion/Compilation/IlCompilerContext.cs
@@ -14,7 +14,6 @@ using System.Text;
 
 namespace Hyperion.Compilation
 {
-#if NET45
     internal sealed class IlCompilerContext
     {
         private int _stackDepth;
@@ -94,5 +93,4 @@ namespace Hyperion.Compilation
             _il.EmitCall(opcode, method, optionalTypes);
         }
     }
-#endif
 }

--- a/src/Hyperion/Compilation/IlExpression.cs
+++ b/src/Hyperion/Compilation/IlExpression.cs
@@ -14,7 +14,6 @@ using Hyperion.Extensions;
 
 namespace Hyperion.Compilation
 {
-#if NET45
     internal abstract class IlExpression
     {
         public abstract void Emit(IlCompilerContext ctx);
@@ -323,5 +322,4 @@ namespace Hyperion.Compilation
 
         public override Type Type() => _method.ReturnType;
     }
-#endif
 }

--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -4,24 +4,19 @@
   <PropertyGroup>
     <AssemblyTitle>Hyperion</AssemblyTitle>
     <Description>Hyperion, fast binary POCO serializer</Description>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>serialization;poco</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-  </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
@@ -37,16 +32,8 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD16</DefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NETSTANDARD20</DefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DefineConstants>$(DefineConstants);SERIALIZATION;UNSAFE;NET45</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
+    <DefineConstants>$(DefineConstants);SERIALIZATION;UNSAFE;NETFX</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Hyperion/Hyperion.csproj
+++ b/src/Hyperion/Hyperion.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyTitle>Hyperion</AssemblyTitle>
     <Description>Hyperion, fast binary POCO serializer</Description>
-    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>serialization;poco</PackageTags>
   </PropertyGroup>
@@ -32,7 +32,7 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>$(DefineConstants);SERIALIZATION;UNSAFE;NETFX</DefineConstants>
   </PropertyGroup>
 

--- a/src/Hyperion/Serializer.cs
+++ b/src/Hyperion/Serializer.cs
@@ -40,7 +40,7 @@ namespace Hyperion
         internal readonly ConcurrentDictionary<Type, TypeAccepted> AcceptedTypes =
             new ConcurrentDictionary<Type, TypeAccepted>();
 
-        public Serializer() : this(new SerializerOptions())
+        public Serializer() : this(SerializerOptions.Default)
         {
         }
 

--- a/src/Hyperion/SerializerFactories/AggregateExceptionSerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/AggregateExceptionSerializerFactory.cs
@@ -39,29 +39,15 @@ namespace Hyperion.SerializerFactories
         }
 
         public override bool CanSerialize(Serializer serializer, Type type) => 
-#if NETSTANDARD16
-            false;
-#else
             AggregateExceptionTypeInfo.IsAssignableFrom(type.GetTypeInfo());
-#endif
 
         public override bool CanDeserialize(Serializer serializer, Type type) => CanSerialize(serializer, type);
 
-#if NETSTANDARD16
-        // Workaround for CoreCLR where FormatterServices.GetUninitializedObject is not public
-        private static readonly Func<Type, object> GetUninitializedObject =
-            (Func<Type, object>)
-                typeof(string).GetTypeInfo().Assembly.GetType("System.Runtime.Serialization.FormatterServices")
-                    .GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
-                    .CreateDelegate(typeof(Func<Type, object>));
-#else
         private static readonly Func<Type,object> GetUninitializedObject = System.Runtime.Serialization.FormatterServices.GetUninitializedObject;
-#endif
 
         public override ValueSerializer BuildSerializer(Serializer serializer, Type type,
             ConcurrentDictionary<Type, ValueSerializer> typeMapping)
         {
-#if !NETSTANDARD1_6
             var exceptionSerializer = new ObjectSerializer(type);
             exceptionSerializer.Initialize((stream, session) =>
             {
@@ -121,9 +107,6 @@ namespace Hyperion.SerializerFactories
             else
                 typeMapping.TryAdd(type, exceptionSerializer);
             return exceptionSerializer;
-#else
-            return null;
-#endif
         }
     }
 }

--- a/src/Hyperion/SerializerFactories/ExceptionSerializerFactory.cs
+++ b/src/Hyperion/SerializerFactories/ExceptionSerializerFactory.cs
@@ -37,22 +37,13 @@ namespace Hyperion.SerializerFactories
 
         public override bool CanDeserialize(Serializer serializer, Type type) => CanSerialize(serializer, type);
 
-#if NETSTANDARD16
-        // Workaround for CoreCLR where FormatterServices.GetUninitializedObject is not public
-        private static readonly Func<Type, object> GetUninitializedObject =
-            (Func<Type, object>)
-                typeof(string).GetTypeInfo().Assembly.GetType("System.Runtime.Serialization.FormatterServices")
-                    .GetMethod("GetUninitializedObject", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
-                    .CreateDelegate(typeof(Func<Type, object>));
-#else
         private static readonly Func<Type,object> GetUninitializedObject = System.Runtime.Serialization.FormatterServices.GetUninitializedObject;
-#endif
 
         public override ValueSerializer BuildSerializer(Serializer serializer, Type type,
             ConcurrentDictionary<Type, ValueSerializer> typeMapping)
         {
             var exceptionSerializer = new ObjectSerializer(type);
-            var hasDefaultConstructor = type.GetTypeInfo().GetConstructor(new Type[0]) != null;
+            var hasDefaultConstructor = type.GetTypeInfo().GetConstructor(Type.EmptyTypes) != null;
             var createInstance  = hasDefaultConstructor ? Activator.CreateInstance : GetUninitializedObject;
 
             exceptionSerializer.Initialize((stream, session) =>
@@ -64,11 +55,7 @@ namespace Hyperion.SerializerFactories
                 var stackTraceString = stream.ReadString(session);
                 var innerException = stream.ReadObject(session);
 
-#if NETSTANDARD20
                 _className?.SetValue(exception, className);
-#else
-                _className.SetValue(exception, className);
-#endif
                 _message.SetValue(exception, message);
                 _remoteStackTraceString.SetValue(exception, remoteStackTraceString);
                 _stackTraceString.SetValue(exception, stackTraceString);
@@ -76,11 +63,7 @@ namespace Hyperion.SerializerFactories
                 return exception;
             }, (stream, exception, session) =>
             {
-#if NETSTANDARD20
                 var className = (string)_className?.GetValue(exception);
-#else
-                var className = (string)_className.GetValue(exception);
-#endif
                 var message = (string)_message.GetValue(exception);
                 var remoteStackTraceString = (string)_remoteStackTraceString.GetValue(exception);
                 var stackTraceString = (string)_stackTraceString.GetValue(exception);

--- a/src/Hyperion/SerializerOptions.cs
+++ b/src/Hyperion/SerializerOptions.cs
@@ -16,17 +16,26 @@ namespace Hyperion
 {
     public class SerializerOptions
     {
-        public static readonly SerializerOptions Default = new SerializerOptions();
+        public static readonly SerializerOptions Default = new SerializerOptions(
+            versionTolerance: false,
+            preserveObjectReferences: false,
+            surrogates: null,
+            serializerFactories: null,
+            knownTypes: null,
+            ignoreISerializable: false,
+            packageNameOverrides: null,
+            disallowUnsafeTypes: true,
+            typeFilter: null);
 
         internal static List<Func<string, string>> DefaultPackageNameOverrides()
         {
             return new List<Func<string, string>>
             {
-#if NET45
+#if NETFX
                 str => str.Contains("System.Private.CoreLib,%core%")
                     ? str.Replace("System.Private.CoreLib,%core%", "mscorlib,%core%") 
                     : str
-#elif NETSTANDARD
+#else
                 str => str.Contains("mscorlib,%core%")
                     ? str.Replace("mscorlib,%core%", "System.Private.CoreLib,%core%") 
                     : str
@@ -34,35 +43,43 @@ namespace Hyperion
             };
         }
 
-        internal static readonly Surrogate[] EmptySurrogates = new Surrogate[0];
+        internal static Surrogate[] EmptySurrogates() => Array.Empty<Surrogate>();
 
-        private static readonly ValueSerializerFactory[] DefaultValueSerializerFactories =
+        private static ValueSerializerFactory[] _defaultValueSerializerFactories;
+        private static ValueSerializerFactory[] DefaultValueSerializerFactories
         {
-            new ConsistentArraySerializerFactory(), 
-            new MethodInfoSerializerFactory(),
-            new PropertyInfoSerializerFactory(), 
-            new ConstructorInfoSerializerFactory(),
-            new FieldInfoSerializerFactory(),
-            new DelegateSerializerFactory(), 
-            new ToSurrogateSerializerFactory(),
-            new FromSurrogateSerializerFactory(),
-            new FSharpMapSerializerFactory(), 
-            new FSharpListSerializerFactory(), 
-            //order is important, try dictionaries before enumerables as dicts are also enumerable
-            new AggregateExceptionSerializerFactory(),
-            new ExceptionSerializerFactory(), 
-            new ImmutableCollectionsSerializerFactory(),
-            new ExpandoObjectSerializerFactory(),
-            new DefaultDictionarySerializerFactory(),
-            new DictionarySerializerFactory(),
-            new ArraySerializerFactory(),
-            new MultipleDimensionalArraySerialzierFactory(),
+            get
+            {
+                if(_defaultValueSerializerFactories == null)
+                    _defaultValueSerializerFactories = new ValueSerializerFactory[]
+                    {
+                        new ConsistentArraySerializerFactory(),
+                        new MethodInfoSerializerFactory(),
+                        new PropertyInfoSerializerFactory(),
+                        new ConstructorInfoSerializerFactory(),
+                        new FieldInfoSerializerFactory(),
+                        new DelegateSerializerFactory(),
+                        new ToSurrogateSerializerFactory(),
+                        new FromSurrogateSerializerFactory(),
+                        new FSharpMapSerializerFactory(),
+                        new FSharpListSerializerFactory(),
+                        //order is important, try dictionaries before enumerables as dicts are also enumerable
+                        new AggregateExceptionSerializerFactory(),
+                        new ExceptionSerializerFactory(),
+                        new ImmutableCollectionsSerializerFactory(),
+                        new ExpandoObjectSerializerFactory(),
+                        new DefaultDictionarySerializerFactory(),
+                        new DictionarySerializerFactory(),
+                        new ArraySerializerFactory(),
+                        new MultipleDimensionalArraySerialzierFactory(),
 #if SERIALIZATION
-            new ISerializableSerializerFactory(), //TODO: this will mess up the indexes in the serializer payload
+                        new ISerializableSerializerFactory(), //TODO: this will mess up the indexes in the serializer payload
 #endif
-            new EnumerableSerializerFactory(),
-            
-        };
+                        new EnumerableSerializerFactory(),
+                    };
+                return _defaultValueSerializerFactories;
+            }
+        }
 
         internal readonly bool IgnoreISerializable;
         internal readonly bool PreserveObjectReferences;
@@ -123,12 +140,12 @@ namespace Hyperion
             ITypeFilter typeFilter)
         {
             VersionTolerance = versionTolerance;
-            Surrogates = surrogates?.ToArray() ?? EmptySurrogates;
+            Surrogates = surrogates?.ToArray() ?? EmptySurrogates();
 
             //use the default factories + any user defined
-	        ValueSerializerFactories = serializerFactories == null
-		        ? DefaultValueSerializerFactories
-		        : serializerFactories.Concat(DefaultValueSerializerFactories).ToArray();
+	        ValueSerializerFactories = 
+                serializerFactories?.Concat(DefaultValueSerializerFactories).ToArray() ??
+		        DefaultValueSerializerFactories;
 
             KnownTypes = knownTypes?.ToArray() ?? new Type[] {};
             for (var i = 0; i < KnownTypes.Length; i++)

--- a/src/Hyperion/SerializerOptions.cs
+++ b/src/Hyperion/SerializerOptions.cs
@@ -43,7 +43,16 @@ namespace Hyperion
             };
         }
 
-        internal static Surrogate[] EmptySurrogates() => Array.Empty<Surrogate>();
+        private static Surrogate[] _emptySurrogate;
+        internal static Surrogate[] EmptySurrogates
+        {
+            get
+            {
+                if (_emptySurrogate == null)
+                    _emptySurrogate = new Surrogate[0];
+                return _emptySurrogate;
+            }
+        }
 
         private static ValueSerializerFactory[] _defaultValueSerializerFactories;
         private static ValueSerializerFactory[] DefaultValueSerializerFactories
@@ -140,7 +149,7 @@ namespace Hyperion
             ITypeFilter typeFilter)
         {
             VersionTolerance = versionTolerance;
-            Surrogates = surrogates?.ToArray() ?? EmptySurrogates();
+            Surrogates = surrogates?.ToArray() ?? EmptySurrogates;
 
             //use the default factories + any user defined
 	        ValueSerializerFactories = 

--- a/src/Hyperion/ValueSerializers/SessionAwareByteArrayRequiringValueSerializer.cs
+++ b/src/Hyperion/ValueSerializers/SessionAwareByteArrayRequiringValueSerializer.cs
@@ -31,7 +31,7 @@ namespace Hyperion.ValueSerializers
             _write = GetStatic(writeStaticMethod, typeof(void));
             _read = GetStatic(readStaticMethod, typeof(TElementType));
 
-#if NET45
+#if NETFX
             var c = new IlCompiler<Action<Stream, object, byte[]>>();
 #else
             var c = new Compiler<Action<Stream, object, byte[]>>();
@@ -45,7 +45,7 @@ namespace Hyperion.ValueSerializers
             c.EmitStaticCall(_write, stream, valueTyped, buffer);
 
             _writeCompiled = c.Compile();
-#if NET45
+#if NETFX
             var c2 = new IlCompiler<Func<Stream, byte[], TElementType>>();
 #else
             var c2 = new Compiler<Func<Stream, byte[], TElementType>>();

--- a/src/Hyperion/ValueSerializers/SessionIgnorantValueSerializer.cs
+++ b/src/Hyperion/ValueSerializers/SessionIgnorantValueSerializer.cs
@@ -31,7 +31,7 @@ namespace Hyperion.ValueSerializers
             _write = GetStatic(writeStaticMethod, typeof(void));
             _read = GetStatic(readStaticMethod, typeof(TElementType));
 
-#if NET45
+#if NETFX
             var c = new IlCompiler<Action<Stream, object>>();
 #else
             var c = new Compiler<Action<Stream, object>>();
@@ -44,7 +44,7 @@ namespace Hyperion.ValueSerializers
 
             _writeCompiled = c.Compile();
 
-#if NET45
+#if NETFX
             var c2 = new IlCompiler<Func<Stream, TElementType>>();
 #else
             var c2 = new Compiler<Func<Stream, TElementType>>();


### PR DESCRIPTION
## Changes

- Remove `netstandard1.6` from the target plarform list
- Remove all `netstandard1.6` API compatibility hacks
- Add supporting nuget packages for `netstandard2.0`