### PR TITLE
Harden DateTimeOffsetSerializer

### DIFF
--- a/src/Hyperion/ValueSerializers/DateTimeOffsetSerializer.cs
+++ b/src/Hyperion/ValueSerializers/DateTimeOffsetSerializer.cs
@@ -39,8 +39,9 @@ namespace Hyperion.ValueSerializers
         {
             stream.ReadFull(bytes, 0, Size);
             var dateTimeTicks = BitConverter.ToInt64(bytes, 0);
-            var offsetTicks = BitConverter.ToInt64(bytes, sizeof(long));
-            var dateTimeOffset = new DateTimeOffset(dateTimeTicks, TimeSpan.FromTicks(offsetTicks));
+            var offset = TimeSpan.FromTicks(BitConverter.ToInt64(bytes, sizeof(long)));
+            var offsetMinutes = TimeSpan.FromMinutes(Math.Round(offset.TotalMinutes));
+            var dateTimeOffset = new DateTimeOffset(dateTimeTicks, offsetMinutes);
             return dateTimeOffset;
         }
 


### PR DESCRIPTION
`DateTimeOffset` ctor will throw if the `TimeSpan` offset parameter were not a whole minute.

> [!NOTE]
>
> This fix will break the fact that serializer/deserializer should faithfully serialize/deserialize data as they were stored even when it is corrupted by attempting to fix the corrupted data. Should we do this or not?

## Changes

Always round the `DateTimeOffset` offset ctor argument to the closest minute.